### PR TITLE
Fixing a problem with commit() not internally using the correct argument when passing on internally

### DIFF
--- a/Source/artifacts/IArtifacts.ts
+++ b/Source/artifacts/IArtifacts.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Constructor } from '@dolittle/types';
-import { UnableToResolveArtifact, ArtifactId, Artifact, Generation } from './index';
+import { ArtifactId, Artifact, Generation } from './index';
 
 /**
  * Defines the system for working with {Artifact}

--- a/Source/events/EventStore.ts
+++ b/Source/events/EventStore.ts
@@ -43,7 +43,7 @@ export class EventStore implements IEventStore {
             return this.commitInternal(eventOrEvents, eventSourceIdOrCancellation as Cancellation);
         }
         const eventSourceId = eventSourceIdOrCancellation as Guid | string;
-        return this.commitInternal([this.toUncommittedEvent(event, eventSourceId, artifact, false)], cancellation);
+        return this.commitInternal([this.toUncommittedEvent(eventOrEvents, eventSourceId, artifact, false)], cancellation);
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
The code assumed one of the overload signatures, while it is the last signature that decides what is actually available.
The exception that was thrown was 'event is not defined', which is true when looking at the transpiled output of the original code.
