### PR TITLE
Fixing equality check for generation

### DIFF
--- a/Source/artifacts/Artifacts.ts
+++ b/Source/artifacts/Artifacts.ts
@@ -119,6 +119,6 @@ export class Artifacts implements IArtifacts {
     }
 
     private artifactEquals(left: Artifact, right: Artifact): boolean {
-        return left.generation === right.generation && left.id.toString() === right.id.toString();
+        return left.generation.equals(right.generation) && left.id.toString() === right.id.toString();
     }
 }


### PR DESCRIPTION
The consequence of this when used by the EventHandlerProcessor is that it never matched any types associated and all events became `[object Object]`.