### PR TITLE
avoid recursive imports for index

### DIFF
--- a/Source/sdk/Client.ts
+++ b/Source/sdk/Client.ts
@@ -15,7 +15,7 @@ import { Cancellation } from '@dolittle/sdk.resilience';
 
 import { EventStoreClient } from '@dolittle/runtime.contracts/Runtime/Events/EventStore_grpc_pb';
 import { SubscriptionsClient } from '@dolittle/runtime.contracts/Runtime/EventHorizon/Subscriptions_grpc_pb';
-import { LoggingBuilder, LoggingBuilderCallback } from './index';
+import { LoggingBuilder, LoggingBuilderCallback } from './LoggingBuilder';
 
 
 /**

--- a/Source/sdk/index.ts
+++ b/Source/sdk/index.ts
@@ -3,5 +3,5 @@
 
 import '@dolittle/sdk.protobuf';
 
-export { Client, ClientBuilder } from './Client';
 export { LoggingBuilder, LoggingBuilderCallback, WinstonOptionsCallback } from './LoggingBuilder';
+export { Client, ClientBuilder } from './Client';


### PR DESCRIPTION
Client had an import to index which in turn exports Client. This can cause some real weird errors.