### PR TITLE
Making sibling imports explicit

### DIFF
--- a/Source/artifacts/Artifact.ts
+++ b/Source/artifacts/Artifact.ts
@@ -1,11 +1,8 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import {
-    Generation,
-    ArtifactId,
-    ArtifactsFromDecorators
-} from './index';
+import { Generation } from './Generation';
+import { ArtifactId } from './ArtifactId';
 import { Guid } from '@dolittle/rudiments';
 
 /**

--- a/Source/artifacts/ArtifactAssociation.ts
+++ b/Source/artifacts/ArtifactAssociation.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Constructor } from '@dolittle/types';
-import { Artifact } from './index';
+import { Artifact } from './Artifact';
 
 /**
  * Represents an association between a type and an artifact.

--- a/Source/artifacts/ArtifactMap.ts
+++ b/Source/artifacts/ArtifactMap.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Artifact, ArtifactId, Generation } from './index';
-import { Guid } from '@dolittle/rudiments';
+import { Artifact } from './Artifact';
 
 /**
  * Represents a map for mapping an artifact to a given type and provide.

--- a/Source/artifacts/Artifacts.ts
+++ b/Source/artifacts/Artifacts.ts
@@ -3,17 +3,15 @@
 
 import { BehaviorSubject, ReplaySubject } from 'rxjs';
 import { Constructor } from '@dolittle/types';
-import {
-    IArtifacts,
-    ArtifactAssociation,
-    Artifact,
-    ArtifactsFromDecorators,
-    ArtifactId,
-    UnknownType,
-    UnableToResolveArtifact,
-    UnknownArtifact,
-    Generation
-} from './index';
+import { IArtifacts } from './IArtifacts';
+import { ArtifactAssociation } from './';
+import { Artifact } from './Artifact';
+import { ArtifactsFromDecorators } from './ArtifactsFromDecorators';
+import { ArtifactId } from './ArtifactId';
+import { UnknownType } from './UnknownType';
+import { UnableToResolveArtifact } from './UnableToResolveArtifact';
+import { UnknownArtifact } from './UnknownArtifact';
+import { Generation } from './Generation';
 
 /**
  * Represents an implementation of {IArtifacts}

--- a/Source/artifacts/ArtifactsBuilder.ts
+++ b/Source/artifacts/ArtifactsBuilder.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Constructor } from '@dolittle/types';
-import { ArtifactId, Artifact, Artifacts, IArtifacts, Generation } from './index';
+import { Artifact } from './Artifact';
+import { ArtifactId } from './ArtifactId';
+import { Artifacts } from './Artifacts';
+import { IArtifacts } from './IArtifacts';
+import { Generation } from './Generation';
 import { Guid } from '@dolittle/rudiments';
 
 export type ArtifactsBuilderCallback = (builder: ArtifactsBuilder) => void;

--- a/Source/artifacts/ArtifactsFromDecorators.ts
+++ b/Source/artifacts/ArtifactsFromDecorators.ts
@@ -3,7 +3,10 @@
 
 import { ReplaySubject } from 'rxjs';
 import { Constructor } from '@dolittle/types';
-import { Generation, ArtifactId, Artifact, ArtifactAssociation } from './index';
+import { Generation } from './Generation';
+import { ArtifactId } from './ArtifactId';
+import { Artifact } from './Artifact';
+import { ArtifactAssociation } from './ArtifactAssociation';
 
 /**
  * Represents artifacts coming from decorators.

--- a/Source/artifacts/Generation.ts
+++ b/Source/artifacts/Generation.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 import isNaturalNumber from 'is-natural-number';
 import { ConceptAs } from '@dolittle/concepts';
-import { GenerationMustBeNaturalNumber } from './index';
+import { GenerationMustBeNaturalNumber } from './GenerationMustBeNaturalNumber';
 
 /**
  * Represents the generation of an Artifact.

--- a/Source/artifacts/IArtifacts.ts
+++ b/Source/artifacts/IArtifacts.ts
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Constructor } from '@dolittle/types';
-import { ArtifactId, Artifact, Generation } from './index';
+import { ArtifactId } from './ArtifactId';
+import { Artifact } from './Artifact';
+import { Generation } from './Generation';
 
 /**
  * Defines the system for working with {Artifact}

--- a/Source/artifacts/UnableToResolveArtifact.ts
+++ b/Source/artifacts/UnableToResolveArtifact.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Exception } from '@dolittle/rudiments';
-import { Artifact } from './index';
 
 /**
  * Exception that is thrown when an {@link Artifact} is not possible to be resolved

--- a/Source/artifacts/UnknownArtifact.ts
+++ b/Source/artifacts/UnknownArtifact.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Exception } from '@dolittle/rudiments';
-import { Artifact } from './index';
 
 /**
  * Exception that gets thrown when an {@link Artifact} is unknown.

--- a/Source/artifacts/UnknownType.ts
+++ b/Source/artifacts/UnknownType.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Exception } from '@dolittle/rudiments';
-import { Artifact } from './index';
+import { Artifact } from './Artifact';
 
 /**
  * Exception that gets thrown when an {@link Artifact} is unknown.

--- a/Source/artifacts/for_Artifacts/given/no_associations.ts
+++ b/Source/artifacts/for_Artifacts/given/no_associations.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Artifacts } from '../../index';
+import { Artifacts } from '../../Artifacts';
 
 export default {
     artifacts: new Artifacts()

--- a/Source/artifacts/for_Artifacts/given/one_association.ts
+++ b/Source/artifacts/for_Artifacts/given/one_association.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Constructor } from '@dolittle/types';
-import { Artifact, Artifacts, ArtifactId, Generation } from '../../index';
+import { Artifact } from '../../Artifact';
+import { Artifacts } from '../../Artifacts';
 
 class MyType {}
 

--- a/Source/artifacts/for_Artifacts/when_checking_if_has_for_artifact/and_there_is_no_definition.ts
+++ b/Source/artifacts/for_Artifacts/when_checking_if_has_for_artifact/and_there_is_no_definition.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import no_associations from '../given/no_associations';
-import { ArtifactId } from '../../index';
+import { ArtifactId } from '../../ArtifactId';
 
 describe('when checking if has for type and there is no definition', () => {
     const result = no_associations.artifacts.hasTypeFor(ArtifactId.from('7d47a28b-7b87-4b7b-93f7-2d6ce6d56f7b'));

--- a/Source/artifacts/for_Artifacts/when_getting_for_type/and_there_is_no_definition.ts
+++ b/Source/artifacts/for_Artifacts/when_getting_for_type/and_there_is_no_definition.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import no_associations from '../given/no_associations';
-import { UnknownArtifact } from '../../index';
+import { UnknownArtifact } from '../../UnknownArtifact';
 
 class MyType { }
 

--- a/Source/artifacts/for_Artifacts/when_resolving_from_object/and_input_is_artifact.ts
+++ b/Source/artifacts/for_Artifacts/when_resolving_from_object/and_input_is_artifact.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import no_associations from '../given/no_associations';
-import { Artifact, ArtifactId, Generation } from '../../index';
+import { Artifact } from '../../Artifact';
 
 describe('when resolving from object and input is artifact', () => {
     const artifact = Artifact.from('ec0111e1-84e4-4d1a-b7f3-a2f6c4427609');

--- a/Source/artifacts/for_Artifacts/when_resolving_from_object/and_input_is_artifact_id.ts
+++ b/Source/artifacts/for_Artifacts/when_resolving_from_object/and_input_is_artifact_id.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import no_associations from '../given/no_associations';
-import { ArtifactId } from '../../index';
+import { ArtifactId } from '../../ArtifactId';
 
 describe('when resolving from object and input is artifact id', () => {
     const artifactId = ArtifactId.from('ec0111e1-84e4-4d1a-b7f3-a2f6c4427609');

--- a/Source/artifacts/for_Artifacts/when_resolving_from_object/and_input_is_artifact_id_as_string.ts
+++ b/Source/artifacts/for_Artifacts/when_resolving_from_object/and_input_is_artifact_id_as_string.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import no_associations from '../given/no_associations';
-import { ArtifactId } from '../../index';
+import { ArtifactId } from '../../ArtifactId';
 
 describe('when resolving from object and input is artifact id as string', () => {
     const artifactId = 'ec0111e1-84e4-4d1a-b7f3-a2f6c4427609';

--- a/Source/artifacts/for_Artifacts/when_resolving_from_object/with_no_input and_unknown_object.ts
+++ b/Source/artifacts/for_Artifacts/when_resolving_from_object/with_no_input and_unknown_object.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import no_association from '../given/no_associations';
-import { UnableToResolveArtifact } from '../../index';
+import { UnableToResolveArtifact } from '../../UnableToResolveArtifact';
 
 describe('when resolving from object with no input and unknown', () => {
     const object = {};

--- a/Source/artifacts/for_ArtifactsBuilder/when_building/with_no_associations.ts
+++ b/Source/artifacts/for_ArtifactsBuilder/when_building/with_no_associations.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { ArtifactsBuilder } from '../../index';
+import { ArtifactsBuilder } from '../../ArtifactsBuilder';
 
 describe('when building with no associations', () => {
     const builder = new ArtifactsBuilder();

--- a/Source/artifacts/for_ArtifactsBuilder/when_building/with_two_associations.ts
+++ b/Source/artifacts/for_ArtifactsBuilder/when_building/with_two_associations.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { ArtifactId, ArtifactsBuilder, Generation } from '../../index';
+import { ArtifactId } from '../../ArtifactId';
+import { ArtifactsBuilder } from '../../ArtifactsBuilder';
+import { Generation } from '../../Generation';
 
 class FirstType {}
 

--- a/Source/artifacts/package.json
+++ b/Source/artifacts/package.json
@@ -33,9 +33,9 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/concepts": "5.0.0",
-        "@dolittle/rudiments": "5.0.0",
-        "@dolittle/types": "5.0.0",
+        "@dolittle/concepts": "5.0.1",
+        "@dolittle/rudiments": "5.0.1",
+        "@dolittle/types": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.19",
         "is-natural-number": "^4.0.1",
         "rxjs": "6.6.0"

--- a/Source/common/package.json
+++ b/Source/common/package.json
@@ -32,7 +32,7 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/types": "5.0.0"
+        "@dolittle/types": "5.0.1"
     },
     "devDependencies": {}
 }

--- a/Source/eventHorizon/EventHorizons.ts
+++ b/Source/eventHorizon/EventHorizons.ts
@@ -9,16 +9,12 @@ import { callContexts, failures, guids } from '@dolittle/sdk.protobuf';
 import { SubscriptionsClient } from '@dolittle/runtime.contracts/Runtime/EventHorizon/Subscriptions_grpc_pb';
 import { Subscription as PbSubscription, SubscriptionResponse as PbSubscriptionResponse } from '@dolittle/runtime.contracts/Runtime/EventHorizon/Subscriptions_pb';
 
-import {
-    Subscription,
-    IEventHorizons,
-    SubscriptionResponse,
-    TenantWithSubscriptions,
-    SubscriptionCallbacks,
-    SubscriptionDoesNotExist,
-    ConsentId
-} from './index';
-
+import { Subscription } from './Subscription';
+import { IEventHorizons } from './IEventHorizons';
+import { SubscriptionResponse } from './SubscriptionResponse';
+import { TenantWithSubscriptions } from './TenantWithSubscriptions';
+import { SubscriptionCallbacks } from './SubscriptionCallbacks';
+import { SubscriptionDoesNotExist } from './SubscriptionDoesNotExist';
 
 /**
  * Represents an implementation of {@link IEventHorizons}.

--- a/Source/eventHorizon/EventHorizonsBuilder.ts
+++ b/Source/eventHorizon/EventHorizonsBuilder.ts
@@ -5,16 +5,10 @@ import { TenantId, IExecutionContextManager } from '@dolittle/sdk.execution';
 
 import { SubscriptionsClient } from '@dolittle/runtime.contracts/Runtime/EventHorizon/Subscriptions_grpc_pb';
 import { Logger } from 'winston';
-import {
-    TenantWithSubscriptionsBuilder,
-    TenantWithSubscriptionsBuilderCallback,
-    SubscriptionCallbacks,
-    SubscriptionCompleted,
-    SubscriptionSucceeded,
-    SubscriptionFailed,
-    EventHorizons,
-    IEventHorizons
-} from './index';
+import { TenantWithSubscriptionsBuilder, TenantWithSubscriptionsBuilderCallback } from './TenantWithSubscriptionsBuilder';
+import { SubscriptionCallbacks, SubscriptionCompleted, SubscriptionFailed, SubscriptionSucceeded } from './SubscriptionCallbacks';
+import { EventHorizons } from './EventHorizons';
+import { IEventHorizons } from './IEventHorizons';
 import { Guid } from '@dolittle/rudiments';
 
 export type EventHorizonsBuilderCallback = (builder: EventHorizonsBuilder) => void;

--- a/Source/eventHorizon/IEventHorizons.ts
+++ b/Source/eventHorizon/IEventHorizons.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Subscription, TenantWithSubscriptions, SubscriptionResponse } from './index';
+import { Subscription } from './Subscription';
+import { TenantWithSubscriptions } from './TenantWithSubscriptions';
+import { SubscriptionResponse } from './SubscriptionResponse';
 
 /**
  * Defines the capabilities of the event horizons.

--- a/Source/eventHorizon/Subscription.ts
+++ b/Source/eventHorizon/Subscription.ts
@@ -3,7 +3,7 @@
 
 import { PartitionId, ScopeId, StreamId } from '@dolittle/sdk.events';
 import { TenantId, MicroserviceId } from '@dolittle/sdk.execution';
-import { SubscriptionCallbacks } from './index';
+import { SubscriptionCallbacks } from './SubscriptionCallbacks';
 
 /**
  * Represents the configuration of an event horizon subscription.

--- a/Source/eventHorizon/SubscriptionBuilder.ts
+++ b/Source/eventHorizon/SubscriptionBuilder.ts
@@ -9,17 +9,11 @@ import { Guid } from '@dolittle/rudiments';
 import { ScopeId, PartitionId, StreamId } from '@dolittle/sdk.events';
 import { MicroserviceId, TenantId } from '@dolittle/sdk.execution';
 
-import {
-    Subscription,
-    SubscriptionCallbacks,
-    SubscriptionCallbackArguments,
-    SubscriptionCompleted,
-    SubscriptionSucceeded,
-    SubscriptionFailed,
-    MissingScopeForSubscription,
-    MissingTenantForSubscription,
-    MissingStreamForSubscription
-} from './index';
+import { Subscription } from './Subscription';
+import { SubscriptionCallbacks, SubscriptionCallbackArguments, SubscriptionCompleted, SubscriptionFailed, SubscriptionSucceeded} from './SubscriptionCallbacks';
+import { MissingScopeForSubscription } from './MissingScopeForSubscription';
+import { MissingTenantForSubscription } from './MissingTenantForSubscription';
+import { MissingStreamForSubscription } from './MissingStreamForSubscription';
 
 /**
  * Represents the callback for the {@link SubscriptionBuilder}.

--- a/Source/eventHorizon/SubscriptionCallbacks.ts
+++ b/Source/eventHorizon/SubscriptionCallbacks.ts
@@ -4,7 +4,9 @@
 import { Subject, Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { TenantId } from '@dolittle/sdk.execution';
-import { CallbackShouldBeFunction, Subscription, SubscriptionResponse } from './index';
+import { CallbackShouldBeFunction } from './CallbackShouldBeFunction';
+import { Subscription } from './Subscription';
+import { SubscriptionResponse } from './SubscriptionResponse';
 
 /**
  * Callback that gets called when a subscription has been completed

--- a/Source/eventHorizon/SubscriptionDoesNotExist.ts
+++ b/Source/eventHorizon/SubscriptionDoesNotExist.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Exception } from '@dolittle/rudiments';
-import { Subscription } from './index';
+import { Subscription } from './Subscription';
 
 /**
  * Exception that gets thrown when a subscription does not exist.

--- a/Source/eventHorizon/SubscriptionResponse.ts
+++ b/Source/eventHorizon/SubscriptionResponse.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Failure } from '@dolittle/sdk.protobuf';
-import { ConsentId } from './index';
-import { SubscriptionSucceeded } from './SubscriptionCallbacks';
+import { ConsentId } from './ConsentId';
 import { Guid } from '@dolittle/rudiments';
 
 /**

--- a/Source/eventHorizon/TenantWithSubscriptions.ts
+++ b/Source/eventHorizon/TenantWithSubscriptions.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { TenantId } from '@dolittle/sdk.execution';
-import { Subscription, SubscriptionCallbacks } from './index';
+import { Subscription } from './Subscription';
+import { SubscriptionCallbacks } from './SubscriptionCallbacks';
 
 /**
  * Represents an event horizon.

--- a/Source/eventHorizon/TenantWithSubscriptionsBuilder.ts
+++ b/Source/eventHorizon/TenantWithSubscriptionsBuilder.ts
@@ -4,16 +4,9 @@
 import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { MicroserviceId, TenantId } from '@dolittle/sdk.execution';
-import {
-    TenantWithSubscriptions,
-    SubscriptionBuilder,
-    SubscriptionCallbacks,
-    SubscriptionCallbackArguments,
-    SubscriptionBuilderCallback,
-    SubscriptionCompleted,
-    SubscriptionSucceeded,
-    SubscriptionFailed
-} from './index';
+import { TenantWithSubscriptions } from './';
+import { SubscriptionBuilder, SubscriptionBuilderCallback } from './SubscriptionBuilder';
+import { SubscriptionCallbacks, SubscriptionCallbackArguments, SubscriptionCompleted, SubscriptionSucceeded, SubscriptionFailed } from './SubscriptionCallbacks';
 import { Guid } from '@dolittle/rudiments';
 
 export type TenantWithSubscriptionsBuilderCallback = (builder: TenantWithSubscriptionsBuilder) => void;

--- a/Source/eventHorizon/package.json
+++ b/Source/eventHorizon/package.json
@@ -33,7 +33,7 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/rudiments": "5.0.0",
+        "@dolittle/rudiments": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.19",
         "@dolittle/sdk.events": "7.0.1",
         "@dolittle/sdk.artifacts": "7.0.1",

--- a/Source/events.filtering/EventFiltersBuilder.ts
+++ b/Source/events.filtering/EventFiltersBuilder.ts
@@ -9,7 +9,10 @@ import { Cancellation } from '@dolittle/sdk.resilience';
 
 import { FiltersClient } from '@dolittle/runtime.contracts/Runtime/Events.Processing/Filters_grpc_pb';
 
-import { FilterId, Filters, IFilters, PublicEventFilterBuilder } from './index';
+import { FilterId } from './FilterId';
+import { Filters } from './Filters';
+import { IFilters } from './IFilters';
+import { PublicEventFilterBuilder } from './PublicEventFilterBuilder';
 import { Guid } from '@dolittle/rudiments';
 import { PrivateEventFilterBuilder } from './PrivateEventFilterBuilder';
 

--- a/Source/events.filtering/FilterDefinitionIncomplete.ts
+++ b/Source/events.filtering/FilterDefinitionIncomplete.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Exception } from '@dolittle/rudiments';
-import { FilterId } from './index';
+import { FilterId } from './FilterId';
 
 /**
  * Exception that is thrown when a filter definition is started using the {@link EventFiltersBuilder}, but not completed..

--- a/Source/events.filtering/Filters.ts
+++ b/Source/events.filtering/Filters.ts
@@ -6,7 +6,8 @@ import { delay } from 'rxjs/operators';
 
 import { Cancellation, retryPipe } from '@dolittle/sdk.resilience';
 
-import { IFilters, IFilterProcessor } from './index';
+import { IFilters } from './IFilters';
+import { IFilterProcessor } from './IFilterProcessor';
 
 /**
  * Represents an implementation of {@link IFilters}.

--- a/Source/events.filtering/IFilters.ts
+++ b/Source/events.filtering/IFilters.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Cancellation } from '@dolittle/sdk.resilience';
-import { IFilterProcessor } from './index';
+import { IFilterProcessor } from './IFilterProcessor';
 
 /**
  * Defines the API for working with filters.

--- a/Source/events.filtering/Internal/EventFilterProcessor.ts
+++ b/Source/events.filtering/Internal/EventFilterProcessor.ts
@@ -16,7 +16,7 @@ import { FilterRegistrationRequest, FilterEventRequest, FilterResponse, FilterRe
 import { ProcessorFailure } from '@dolittle/runtime.contracts/Runtime/Events.Processing/Processors_pb';
 
 import { FilterId, FilterEventCallback } from '../index';
-import { FilterEventProcessor } from './index';
+import { FilterEventProcessor } from './FilterEventProcessor';
 
 export class EventFilterProcessor extends FilterEventProcessor<FilterRegistrationRequest, FilterResponse> {
 

--- a/Source/events.filtering/Internal/PartitionedEventFilterProcessor.ts
+++ b/Source/events.filtering/Internal/PartitionedEventFilterProcessor.ts
@@ -16,7 +16,7 @@ import { FilterEventRequest, FilterRegistrationResponse, FilterRuntimeToClientMe
 import { PartitionedFilterClientToRuntimeMessage, PartitionedFilterRegistrationRequest, PartitionedFilterResponse } from '@dolittle/runtime.contracts/Runtime/Events.Processing/PartitionedFilters_pb';
 import { ProcessorFailure } from '@dolittle/runtime.contracts/Runtime/Events.Processing/Processors_pb';
 
-import { FilterEventProcessor } from './index';
+import { FilterEventProcessor } from './FilterEventProcessor';
 import { FilterId, PartitionedFilterEventCallback } from '../index';
 
 export class PartitionedEventFilterProcessor extends FilterEventProcessor<PartitionedFilterRegistrationRequest, PartitionedFilterResponse> {

--- a/Source/events.filtering/Internal/PublicEventFilterProcessor.ts
+++ b/Source/events.filtering/Internal/PublicEventFilterProcessor.ts
@@ -18,7 +18,7 @@ import { PublicFilterClientToRuntimeMessage, PublicFilterRegistrationRequest } f
 import { ProcessorFailure } from '@dolittle/runtime.contracts/Runtime/Events.Processing/Processors_pb';
 
 import { FilterId, PartitionedFilterEventCallback } from '../index';
-import { FilterEventProcessor } from './index';
+import { FilterEventProcessor } from './FilterEventProcessor';
 
 export class PublicEventFilterProcessor extends FilterEventProcessor<PublicFilterRegistrationRequest, PartitionedFilterResponse> {
 

--- a/Source/events.filtering/MissingFilterCallback.ts
+++ b/Source/events.filtering/MissingFilterCallback.ts
@@ -3,7 +3,7 @@
 
 import { Exception } from '@dolittle/rudiments';
 import { ScopeId } from '@dolittle/sdk.events';
-import { FilterId } from './index';
+import { FilterId } from './FilterId';
 
 /**
  * Exception that is thrown when a filter callback is not defined.

--- a/Source/events.filtering/PartitionedEventFilterBuilder.ts
+++ b/Source/events.filtering/PartitionedEventFilterBuilder.ts
@@ -9,7 +9,11 @@ import { IExecutionContextManager } from '@dolittle/sdk.execution';
 
 import { FiltersClient } from '@dolittle/runtime.contracts/Runtime/Events.Processing/Filters_grpc_pb';
 
-import { FilterId, internal, PartitionedFilterEventCallback, IFilterProcessor, MissingFilterCallback } from './index';
+import { FilterId } from './FilterId';
+import * as internal from './Internal';
+import { PartitionedFilterEventCallback } from './PartitionedFilterEventCallback';
+import { IFilterProcessor } from './IFilterProcessor';
+import { MissingFilterCallback } from './MissingFilterCallback';
 import { Guid } from '@dolittle/rudiments';
 
 /**

--- a/Source/events.filtering/PartitionedFilterEventCallback.ts
+++ b/Source/events.filtering/PartitionedFilterEventCallback.ts
@@ -3,6 +3,6 @@
 
 import { EventContext } from '@dolittle/sdk.events';
 
-import { PartitionedFilterResult } from './index';
+import { PartitionedFilterResult } from './PartitionedFilterResult';
 
 export type PartitionedFilterEventCallback = (event: any, context: EventContext) => PartitionedFilterResult | Promise<PartitionedFilterResult>;

--- a/Source/events.filtering/PrivateEventFilterBuilder.ts
+++ b/Source/events.filtering/PrivateEventFilterBuilder.ts
@@ -9,14 +9,12 @@ import { IExecutionContextManager } from '@dolittle/sdk.execution';
 
 import { FiltersClient } from '@dolittle/runtime.contracts/Runtime/Events.Processing/Filters_grpc_pb';
 
-import {
-    PartitionedEventFilterBuilder,
-    UnpartitionedEventFilterBuilder,
-    FilterEventCallback,
-    FilterId,
-    IFilterProcessor,
-    FilterDefinitionIncomplete
-} from './index';
+import { PartitionedEventFilterBuilder } from './PartitionedEventFilterBuilder';
+import { UnpartitionedEventFilterBuilder } from './UnpartitionedEventFilterBuilder';
+import { FilterEventCallback } from './FilterEventCallback';
+import { FilterId } from './FilterId';
+import { IFilterProcessor } from './IFilterProcessor';
+import { FilterDefinitionIncomplete } from './FilterDefinitionIncomplete';
 import { Guid } from '@dolittle/rudiments';
 
 /**

--- a/Source/events.filtering/PublicEventFilterBuilder.ts
+++ b/Source/events.filtering/PublicEventFilterBuilder.ts
@@ -9,7 +9,11 @@ import { ScopeId } from '@dolittle/sdk.events';
 
 import { FiltersClient } from '@dolittle/runtime.contracts/Runtime/Events.Processing/Filters_grpc_pb';
 
-import { FilterId, PartitionedFilterEventCallback, IFilterProcessor, internal, MissingFilterCallback } from './index';
+import { FilterId } from './FilterId';
+import { PartitionedFilterEventCallback } from './PartitionedFilterEventCallback';
+import { IFilterProcessor } from './IFilterProcessor';
+import * as internal from './Internal';
+import { MissingFilterCallback } from './MissingFilterCallback';
 
 /**
  * Represents the builder for building public event filters.

--- a/Source/events.filtering/UnpartitionedEventFilterBuilder.ts
+++ b/Source/events.filtering/UnpartitionedEventFilterBuilder.ts
@@ -9,7 +9,11 @@ import { IExecutionContextManager } from '@dolittle/sdk.execution';
 
 import { FiltersClient } from '@dolittle/runtime.contracts/Runtime/Events.Processing/Filters_grpc_pb';
 
-import { FilterId, FilterEventCallback, IFilterProcessor, MissingFilterCallback, internal } from './index';
+import { FilterId } from './FilterId';
+import { FilterEventCallback } from './FilterEventCallback';
+import { IFilterProcessor } from './IFilterProcessor';
+import { MissingFilterCallback } from './MissingFilterCallback';
+import * as internal from './Internal';
 
 /**
  * Represents the builder for building public event filters.

--- a/Source/events.filtering/index.ts
+++ b/Source/events.filtering/index.ts
@@ -15,4 +15,3 @@ export { PartitionedEventFilterBuilder } from './PartitionedEventFilterBuilder';
 export { PrivateEventFilterBuilder } from './PrivateEventFilterBuilder';
 export { PublicEventFilterBuilder } from './PublicEventFilterBuilder';
 export { EventFiltersBuilder, EventFiltersBuilderCallback, PrivateEventFilterBuilderCallback, PublicEventFilterBuilderCallback } from './EventFiltersBuilder';
-export * as internal from './Internal';

--- a/Source/events.filtering/package.json
+++ b/Source/events.filtering/package.json
@@ -32,7 +32,7 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/rudiments": "5.0.0",
+        "@dolittle/rudiments": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.19",
         "@dolittle/sdk.artifacts": "7.0.1",
         "@dolittle/sdk.events": "7.0.1",

--- a/Source/events.handling/EventHandler.ts
+++ b/Source/events.handling/EventHandler.ts
@@ -6,7 +6,13 @@ import { Guid } from '@dolittle/rudiments';
 import { Artifact, ArtifactMap } from '@dolittle/sdk.artifacts';
 import { EventContext, ScopeId } from '@dolittle/sdk.events';
 
-import { EventHandlerDecoratedTypes, IEventHandler, EventHandlerSignature, MissingEventHandlerForType, EventHandlerId, EventHandlerDecoratedType, EventHandlerOptions} from './index';
+import { EventHandlerDecoratedTypes } from './EventHandlerDecoratedTypes';
+import { IEventHandler } from './IEventHandler';
+import { EventHandlerSignature } from './EventHandlerSignature';
+import { MissingEventHandlerForType } from './MissingEventHandlerForType';
+import { EventHandlerId } from './EventHandlerId';
+import { EventHandlerDecoratedType } from './EventHandlerDecoratedType';
+import { EventHandlerOptions } from './EventHandlerOptions';
 
 /**
  * Represents an implementation of {@link IEventHandler}.

--- a/Source/events.handling/EventHandlerBuilder.ts
+++ b/Source/events.handling/EventHandlerBuilder.ts
@@ -6,7 +6,10 @@ import { Guid } from '@dolittle/rudiments';
 import { Artifact, IArtifacts, ArtifactMap } from '@dolittle/sdk.artifacts';
 import { ScopeId } from '@dolittle/sdk.events';
 
-import { EventHandlerSignature, EventHandlerId, IEventHandler, EventHandler } from './index';
+import { IEventHandler } from './IEventHandler';
+import { EventHandler } from './EventHandler';
+import { EventHandlerSignature } from './EventHandlerSignature';
+import { EventHandlerId } from './EventHandlerId';
 
 export type EventHandlerBuilderCallback = (builder: EventHandlerBuilder) => void;
 

--- a/Source/events.handling/EventHandlerDecoratedType.ts
+++ b/Source/events.handling/EventHandlerDecoratedType.ts
@@ -3,7 +3,7 @@
 
 import { ScopeId } from '@dolittle/sdk.events';
 
-import { EventHandlerId } from './index';
+import { EventHandlerId } from './EventHandlerId';
 
 /**
  * Represents an event handler created from the decorator

--- a/Source/events.handling/EventHandlerDecoratedTypes.ts
+++ b/Source/events.handling/EventHandlerDecoratedTypes.ts
@@ -3,7 +3,7 @@
 
 import { ReplaySubject } from 'rxjs';
 
-import { EventHandlerDecoratedType } from './index';
+import { EventHandlerDecoratedType } from './EventHandlerDecoratedType';
 
 /**
  * Handles registering and mappings between @eventHandler decorated classes and their given id and options.

--- a/Source/events.handling/EventHandlers.ts
+++ b/Source/events.handling/EventHandlers.ts
@@ -12,7 +12,14 @@ import { Cancellation, retryPipe } from '@dolittle/sdk.resilience';
 
 import { EventHandlersClient } from '@dolittle/runtime.contracts/Runtime/Events.Processing/EventHandlers_grpc_pb';
 
-import { EventHandler, internal, IEventHandlers, EventHandlerDecoratedTypes, EventHandlerDecoratedType, HandlesDecoratedMethods, EventHandlerSignature, IEventHandler } from './index';
+import * as internal from './Internal';
+import { EventHandler } from './EventHandler';
+import { IEventHandlers } from './IEventHandlers';
+import { EventHandlerDecoratedTypes } from './EventHandlerDecoratedTypes';
+import { EventHandlerDecoratedType } from './EventHandlerDecoratedType';
+import { HandlesDecoratedMethods } from './HandlesDecoratedMethods';
+import { EventHandlerSignature } from './EventHandlerSignature';
+import { IEventHandler } from './IEventHandler';
 import { ScopeId } from '@dolittle/sdk.events';
 
 class EventHandlerRegistration {
@@ -84,7 +91,7 @@ export class EventHandlers implements IEventHandlers {
                         return method.method(event, eventContext);
                     });
                 }
-                const eventHandler = new EventHandler(value.eventHandlerId, value.scopeId || ScopeId.default, true, methodsByArtifact);
+                const eventHandler = new EventHandler(value.eventHandlerId, value.scopeId || ScopeId.default, true, methodsByArtifact);
                 return new EventHandlerRegistration(eventHandler, this._cancellation, value.type);
             })
         ).subscribe(this._eventHandlers);

--- a/Source/events.handling/EventHandlersBuilder.ts
+++ b/Source/events.handling/EventHandlersBuilder.ts
@@ -12,7 +12,10 @@ import { Cancellation } from '@dolittle/sdk.resilience';
 
 import { EventHandlersClient } from '@dolittle/runtime.contracts/Runtime/Events.Processing/EventHandlers_grpc_pb';
 
-import { IEventHandlers, EventHandlerId, EventHandlerBuilder, EventHandlerBuilderCallback, EventHandlers } from './index';
+import { IEventHandlers } from './IEventHandlers';
+import { EventHandlerId } from './EventHandlerId';
+import { EventHandlerBuilder, EventHandlerBuilderCallback } from './EventHandlerBuilder';
+import { EventHandlers } from './EventHandlers';
 
 export type EventHandlersBuilderCallback = (builder: EventHandlersBuilder) => void;
 

--- a/Source/events.handling/HandlesDecoratedMethod.ts
+++ b/Source/events.handling/HandlesDecoratedMethod.ts
@@ -3,7 +3,7 @@
 
 import { Constructor } from '@dolittle/types';
 
-import { EventHandlerSignature } from './index';
+import { EventHandlerSignature } from './EventHandlerSignature';
 
 /**
  * Represents methods decorated with the handles decorator.

--- a/Source/events.handling/HandlesDecoratedMethods.ts
+++ b/Source/events.handling/HandlesDecoratedMethods.ts
@@ -3,7 +3,8 @@
 
 import { Constructor } from '@dolittle/types';
 
-import { HandlesDecoratedMethod, EventHandlerSignature } from './index';
+import { HandlesDecoratedMethod } from './HandlesDecoratedMethod';
+import { EventHandlerSignature } from './EventHandlerSignature';
 
 /**
  * Defines the system that knows about all the methods decorated with the handle decorator.

--- a/Source/events.handling/IEventHandler.ts
+++ b/Source/events.handling/IEventHandler.ts
@@ -4,7 +4,7 @@
 import { Artifact } from '@dolittle/sdk.artifacts';
 import { EventContext, ScopeId } from '@dolittle/sdk.events';
 
-import { EventHandlerId } from './index';
+import { EventHandlerId } from './EventHandlerId';
 
 /**
  * Defines an event handler

--- a/Source/events.handling/IEventHandlers.ts
+++ b/Source/events.handling/IEventHandlers.ts
@@ -3,7 +3,7 @@
 
 import { Cancellation } from '@dolittle/sdk.resilience';
 
-import { IEventHandler } from './index';
+import { IEventHandler } from './IEventHandler';
 
 /**
  * Defines the system for event handlers

--- a/Source/events.handling/package.json
+++ b/Source/events.handling/package.json
@@ -33,7 +33,7 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/types": "5.0.0",
+        "@dolittle/types": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.19",
         "@dolittle/sdk.artifacts": "7.0.1",
         "@dolittle/sdk.common": "7.0.1",

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -32,8 +32,8 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/concepts": "5.0.0",
-        "@dolittle/rudiments": "5.0.0",
+        "@dolittle/concepts": "5.0.1",
+        "@dolittle/rudiments": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.19",
         "@dolittle/sdk.artifacts": "7.0.1",
         "@dolittle/sdk.events": "7.0.1",

--- a/Source/events/CommitEventsResponse.ts
+++ b/Source/events/CommitEventsResponse.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Failure } from '@dolittle/sdk.protobuf';
-;import { CommittedEvents } from './index';
+;import { CommittedEvents } from './CommittedEvents';
 
 /**
  * Represents the response from a commit of events

--- a/Source/events/CommittedEvent.ts
+++ b/Source/events/CommittedEvent.ts
@@ -4,7 +4,8 @@
 import { DateTime } from 'luxon';
 import { Artifact } from '@dolittle/sdk.artifacts';
 import { ExecutionContext } from '@dolittle/sdk.execution';
-import { EventSourceId, EventLogSequenceNumber } from './index';
+import { EventSourceId } from './EventSourceId';
+import { EventLogSequenceNumber } from './EventLogSequenceNumber';
 
 /**
  * Represents a committed event

--- a/Source/events/CommittedEvents.ts
+++ b/Source/events/CommittedEvents.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { CommittedEvent } from './index';
+import { CommittedEvent } from './CommittedEvent';
 
 /**
  * Represents a collection of committed events.

--- a/Source/events/EventContext.ts
+++ b/Source/events/EventContext.ts
@@ -3,7 +3,7 @@
 
 import { DateTime } from 'luxon';
 import { ExecutionContext } from '@dolittle/sdk.execution';
-import { EventSourceId } from './index';
+import { EventSourceId } from './EventSourceId';
 
 /**
  * Represents the context of an event.

--- a/Source/events/EventConverters.ts
+++ b/Source/events/EventConverters.ts
@@ -9,7 +9,10 @@ import { UncommittedEvent as PbUncommittedEvent } from '@dolittle/runtime.contra
 import { Artifact } from '@dolittle/sdk.artifacts';
 import { artifacts, guids, executionContexts } from '@dolittle/sdk.protobuf';
 
-import { CommittedEvent as SdkCommittedEvent, EventSourceId, MissingExecutionContext, EventLogSequenceNumber } from './index';
+import { CommittedEvent as SdkCommittedEvent } from './CommittedEvent';
+import { EventSourceId } from './EventSourceId';
+import { MissingExecutionContext } from './MissingExecutionContext';
+import { EventLogSequenceNumber } from './EventLogSequenceNumber';
 
 /**
  * Represents converter helpers for converting to relevant event types for transmitting over Grpc.

--- a/Source/events/EventLogSequenceNumber.ts
+++ b/Source/events/EventLogSequenceNumber.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 import isNaturalNumber from 'is-natural-number';
 import { ConceptAs } from '@dolittle/concepts';
-import { EventLogSequenceNumberMustBeNaturalNumber } from './index';
+import { EventLogSequenceNumberMustBeNaturalNumber } from './EventLogSequenceNumberMustBeNaturalNumber';
 
 /**
  * Represents the event log sequence number of a Committed Event.

--- a/Source/events/EventStore.ts
+++ b/Source/events/EventStore.ts
@@ -13,7 +13,12 @@ import { reactiveUnary } from '@dolittle/sdk.services';
 import { EventStoreClient } from '@dolittle/runtime.contracts/Runtime/Events/EventStore_grpc_pb';
 import { CommitEventsRequest, CommitEventsResponse as PbCommitEventsResponse } from '@dolittle/runtime.contracts/Runtime/Events/EventStore_pb';
 
-import { CommittedEvents, IEventStore, EventSourceId, UncommittedEvent, EventConverters, CommitEventsResponse } from './index';
+import { CommittedEvents } from './CommittedEvents';
+import { IEventStore } from './IEventStore';
+import { EventSourceId } from './EventSourceId';
+import { UncommittedEvent } from './UncommittedEvent';
+import { EventConverters } from './EventConverters';
+import { CommitEventsResponse } from './CommitEventsResponse';
 import { Guid } from '@dolittle/rudiments';
 
 /**

--- a/Source/events/IEventStore.ts
+++ b/Source/events/IEventStore.ts
@@ -1,10 +1,12 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { ArtifactId, Artifact } from '@dolittle/sdk.artifacts';
+import { Artifact } from '@dolittle/sdk.artifacts';
 import { Cancellation } from '@dolittle/sdk.resilience';
 
-import { CommitEventsResponse, EventSourceId, UncommittedEvent } from './index';import { Guid } from '@dolittle/rudiments';
+import { CommitEventsResponse } from './CommitEventsResponse';
+import { UncommittedEvent } from './UncommittedEvent';
+import { Guid } from '@dolittle/rudiments';
 ;
 
 /**

--- a/Source/events/UncommittedEvent.ts
+++ b/Source/events/UncommittedEvent.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { ArtifactId, Artifact } from '@dolittle/sdk.artifacts';
-import { EventSourceId } from './index';
+import { EventSourceId } from './EventSourceId';
 
 /**
  * Represents and uncommitted event

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -33,8 +33,8 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/rudiments": "5.0.0",
-        "@dolittle/concepts": "5.0.0",
+        "@dolittle/rudiments": "5.0.1",
+        "@dolittle/concepts": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.19",
         "@dolittle/sdk.artifacts": "7.0.1",
         "@dolittle/sdk.execution": "7.0.1",

--- a/Source/execution/Claims.ts
+++ b/Source/execution/Claims.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Claim } from './index';
+import { Claim } from './Claim';
 
 /**
  * Represents a collection of claims.

--- a/Source/execution/ExecutionContext.ts
+++ b/Source/execution/ExecutionContext.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Version, MicroserviceId, TenantId, Claims, CorrelationId, Environment } from './index';
+import { Version } from './Version';
+import { MicroserviceId } from './MicroserviceId';
+import { TenantId } from './TenantId';
+import { Claims } from './Claims';
+import { CorrelationId } from './CorrelationId';
+import { Environment } from './Environment';
 
 /**
  * Represents the execution context in a running application.

--- a/Source/execution/ExecutionContextManager.ts
+++ b/Source/execution/ExecutionContextManager.ts
@@ -2,8 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import async_hooks from 'async_hooks';
-import { Claims, IExecutionContextManager, MicroserviceId, Version, ExecutionContext, TenantId, CorrelationId, Environment } from './index';
-import { Guid } from '@dolittle/rudiments';
+import { Claims } from './Claims';
+import { IExecutionContextManager } from './IExecutionContextManager';
+import { MicroserviceId } from './MicroserviceId';
+import { Version } from './Version';
+import { ExecutionContext } from './ExecutionContext';
+import { TenantId } from './TenantId';
+import { CorrelationId } from './CorrelationId';
+import { Environment } from './Environment';
 
 
 /**

--- a/Source/execution/IExecutionContextManager.ts
+++ b/Source/execution/IExecutionContextManager.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { ExecutionContextManager, ExecutionContext, TenantId, Claims } from './index';
+import { ExecutionContextManager } from './ExecutionContextManager';
+import { ExecutionContext } from './ExecutionContext';
+import { TenantId } from './TenantId';
+import { Claims } from './Claims';
 import { Guid } from '@dolittle/rudiments';
 
 /**

--- a/Source/execution/MicroserviceBuilder.ts
+++ b/Source/execution/MicroserviceBuilder.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { MicroserviceId, Version } from './index';
+import { MicroserviceId } from './MicroserviceId';
+import { Version } from './Version';
 
 export type MicroserviceBuilderCallback = (builder: MicroserviceBuilder) => void;
 

--- a/Source/execution/package.json
+++ b/Source/execution/package.json
@@ -33,7 +33,7 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/concepts": "5.0.0",
-        "@dolittle/rudiments": "5.0.0"
+        "@dolittle/concepts": "5.0.1",
+        "@dolittle/rudiments": "5.0.1"
     }
 }

--- a/Source/protobuf/Failure.ts
+++ b/Source/protobuf/Failure.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { FailureId, FailureReason } from './index';
+import { FailureId } from './FailureId';
+import { FailureReason } from './FailureReason';
 import { Guid } from '@dolittle/rudiments';
 
 /**

--- a/Source/protobuf/artifacts.ts
+++ b/Source/protobuf/artifacts.ts
@@ -5,7 +5,8 @@ import { Guid } from '@dolittle/rudiments';
 import { Artifact as SdkArtifact, ArtifactId, Generation } from '@dolittle/sdk.artifacts';
 import { Artifact as PbArtifact } from '@dolittle/runtime.contracts/Fundamentals/Artifacts/Artifact_pb';
 
-import { MissingArtifactIdentifier, guids } from './index';
+import { MissingArtifactIdentifier } from './MissingArtifactIdentifier';
+import guids from './guids';
 
 /**
  * Convert to protobuf representation

--- a/Source/protobuf/callContexts.ts
+++ b/Source/protobuf/callContexts.ts
@@ -3,7 +3,7 @@
 
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { CallRequestContext } from '@dolittle/runtime.contracts/Fundamentals/Services/CallContext_pb';
-import { executionContexts } from './index';
+import executionContexts from './executionContexts';
 
 /**
  * Convert {@link ExecutionContext} to a {@link CallRequestContext}.

--- a/Source/protobuf/executionContexts.ts
+++ b/Source/protobuf/executionContexts.ts
@@ -5,7 +5,9 @@ import { ExecutionContext as SdkExecutionContext, Claims, TenantId, Microservice
 import { ExecutionContext as PbExecutionContext } from '@dolittle/runtime.contracts/Fundamentals/Execution/ExecutionContext_pb';
 import { Claim as PbClaim } from '@dolittle/runtime.contracts/Fundamentals/Security/Claim_pb';
 
-import { claims, guids, versions } from './index';
+import claims from './claims';
+import guids from './guids';
+import versions from './versions';
 
 /**
  * Convert to protobuf representation

--- a/Source/protobuf/failures.ts
+++ b/Source/protobuf/failures.ts
@@ -4,7 +4,9 @@
 import { Failure as PbFailure } from '@dolittle/runtime.contracts/Fundamentals/Protobuf/Failure_pb';
 import { Guid } from '@dolittle/rudiments';
 
-import { Failure as SdkFailure, FailureId, FailureReason, MissingFailureIdentifier, guids} from './index';
+import { Failure as SdkFailure } from './Failure';
+import { MissingFailureIdentifier } from './MissingFailureIdentifier';
+import guids from './guids';
 
 /**
  * Convert to protobuf representation

--- a/Source/protobuf/package.json
+++ b/Source/protobuf/package.json
@@ -35,8 +35,8 @@
     },
     "dependencies": {
         "@dolittle/contracts": "5.1.19",
-        "@dolittle/concepts": "5.0.0",
-        "@dolittle/rudiments": "5.0.0",
+        "@dolittle/concepts": "5.0.1",
+        "@dolittle/rudiments": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.19",
         "@dolittle/sdk.artifacts": "7.0.1",
         "@dolittle/sdk.execution": "7.0.1"

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -34,7 +34,7 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/rudiments": "5.0.0",
+        "@dolittle/rudiments": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.19",
         "@dolittle/sdk.artifacts": "7.0.1",
         "@dolittle/sdk.common": "7.0.1",

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -33,7 +33,7 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/rudiments": "5.0.0",
+        "@dolittle/rudiments": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.19",
         "@dolittle/sdk.execution": "7.0.1",
         "@dolittle/sdk.resilience": "7.0.1",


### PR DESCRIPTION
According to agreed rules:

* add an index file per folder of files, which exports all files
* within a folder, you MUST import siblings directly
* outside a folder, you SHOULD import from the target folder’s index

As agreed in the following [PR](https://github.com/dolittle/JavaScript.SDK/pull/26).