### PR TITLE
Introducing support for Aggregate Roots

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,20 @@
             "outFiles": [
                 "${workspaceFolder}/Samples/Basic/Distribution/*.js"
             ]
+        },
+        {
+            "name": "Launch Aggregates Sample",
+            "type": "node",
+            "request": "launch",
+            "runtimeExecutable": "node",
+            "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"],
+            "args": ["${workspaceFolder}/Samples/Aggregates/index.ts"],
+            "cwd": "${workspaceFolder}/Samples/Aggregates",
+            "preLaunchTask": "tsc: build - Aggregates",
+            "skipFiles": [
+                "<node_internals>/**",
+                "node_modules/**"
+            ]
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,6 +28,27 @@
                 "$tsc"
             ],
             "group": "build"
-        }
+        },
+        {
+            "type": "typescript",
+            "tsconfig": "Samples/Aggregates/tsconfig.json",
+            "problemMatcher": [
+                "$tsc"
+            ],
+            "group": {
+                "isDefault": true,
+                "kind": "build"
+            },
+            "label": "tsc: build - Aggregates",
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            }
+        },
+
     ]
 }

--- a/Samples/Aggregates/.eslintrc.js
+++ b/Samples/Aggregates/.eslintrc.js
@@ -1,0 +1,10 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+module.exports = {
+    extends: '../../.eslintrc.js',
+    rules: {
+        'no-restricted-globals': 'off',
+        '@typescript-eslint/naming-convention' : 'off'
+    }
+};

--- a/Samples/Aggregates/DishHandler.ts
+++ b/Samples/Aggregates/DishHandler.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Sample code for the tutorial at https://dolittle.io/tutorials/getting-started/typescript/
+
+import { EventContext } from '@dolittle/sdk.events';
+import { eventHandler, handles } from '@dolittle/sdk.events.handling';
+import { DishPrepared } from './DishPrepared';
+
+@eventHandler('f2d366cf-c00a-4479-acc4-851e04b6fbba')
+export class DishHandler {
+
+    @handles(DishPrepared)
+    dishPrepared(event: DishPrepared, eventContext: EventContext) {
+        console.log(`${event.Chef} has prepared ${event.Dish}. Yummm!`);
+    }
+}

--- a/Samples/Aggregates/DishPrepared.ts
+++ b/Samples/Aggregates/DishPrepared.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Sample code for the tutorial at https://dolittle.io/tutorials/getting-started/typescript/
+
+import { eventType } from '@dolittle/sdk.events';
+
+@eventType('1844473f-d714-4327-8b7f-5b3c2bdfc26a')
+export class DishPrepared {
+    constructor(readonly Dish: string, readonly Chef: string) {}
+}

--- a/Samples/Aggregates/Kitchen.ts
+++ b/Samples/Aggregates/Kitchen.ts
@@ -16,12 +16,12 @@ export class Kitchen extends AggregateRoot {
 
     prepareDish(dish: string, chef: string) {
         this.apply(new DishPrepared(dish, chef));
+        console.log(`${this._counter} dishes has been prepared so far`);
     }
 
 
     @on(DishPrepared)
     onDishPrepared(event: DishPrepared) {
         this._counter++;
-        console.log(`${this._counter} dishes has been prepared so far`);
     }
 }

--- a/Samples/Aggregates/Kitchen.ts
+++ b/Samples/Aggregates/Kitchen.ts
@@ -22,5 +22,6 @@ export class Kitchen extends AggregateRoot {
     @on(DishPrepared)
     onDishPrepared(event: DishPrepared) {
         this._counter++;
+        console.log(`${this._counter} dishes has been prepared so far`);
     }
 }

--- a/Samples/Aggregates/Kitchen.ts
+++ b/Samples/Aggregates/Kitchen.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Sample code for the tutorial at https://dolittle.io/tutorials/getting-started/typescript/
+
+import { aggregateRoot, AggregateRoot, on } from '@dolittle/sdk.aggregates';
+import { EventSourceId } from '@dolittle/sdk.events';
+import { DishPrepared } from './DishPrepared';
+
+@aggregateRoot('e5b17be9-4873-4526-99a1-76a5c31c0dad')
+export class Kitchen extends AggregateRoot {
+    private _counter: number = 0;
+
+    constructor(eventSourceId: EventSourceId) {
+        super(eventSourceId);
+    }
+
+    prepareDish(dish: string, chef: string) {
+        this.apply(new DishPrepared(dish, chef));
+    }
+
+
+    @on(DishPrepared)
+    onDishPrepared(event: DishPrepared) {
+        this._counter++;
+    }
+}

--- a/Samples/Aggregates/for_Dummy/when_nothing.ts
+++ b/Samples/Aggregates/for_Dummy/when_nothing.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+describe('when nothing', () => {
+    it('should be fine', () => true.should.be.true);
+});

--- a/Samples/Aggregates/index.ts
+++ b/Samples/Aggregates/index.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Sample code for the tutorial at https://dolittle.io/tutorials/getting-started/typescript/
+
+import { Client } from '@dolittle/sdk';
+import { TenantId } from '@dolittle/sdk.execution';
+import { DishPrepared } from './DishPrepared';
+import { DishHandler } from './DishHandler';
+import { Kitchen } from './Kitchen';
+
+const client = Client
+    .forMicroservice('f39b1f61-d360-4675-b859-53c05c87c0e6')
+    .withEventTypes(eventTypes =>
+        eventTypes.register(DishPrepared))
+    .withEventHandlers(builder =>
+        builder.register(DishHandler))
+    .build();
+
+client
+    .aggregateOf(Kitchen,'bfe6f6e4-ada2-4344-8a3b-65a3e1fe16e9',_  => _.forTenant(TenantId.development))
+    .perform(kitchen => kitchen.prepareDish('Bean Blaster Taco', 'Mr. Taco'));
+

--- a/Samples/Aggregates/index.ts
+++ b/Samples/Aggregates/index.ts
@@ -9,8 +9,6 @@ import { DishHandler } from './DishHandler';
 import { Kitchen } from './Kitchen';
 
 (async () => {
-
-
     const client = Client
         .forMicroservice('f39b1f61-d360-4675-b859-53c05c87c0e6')
         .withEventTypes(eventTypes =>
@@ -24,5 +22,4 @@ import { Kitchen } from './Kitchen';
         .perform(kitchen => kitchen.prepareDish('Bean Blaster Taco', 'Mr. Taco'));
 
     console.log('Done');
-
 })();

--- a/Samples/Aggregates/index.ts
+++ b/Samples/Aggregates/index.ts
@@ -20,3 +20,5 @@ client
     .aggregateOf(Kitchen,'bfe6f6e4-ada2-4344-8a3b-65a3e1fe16e9',_  => _.forTenant(TenantId.development))
     .perform(kitchen => kitchen.prepareDish('Bean Blaster Taco', 'Mr. Taco'));
 
+console.log('Done');
+

--- a/Samples/Aggregates/index.ts
+++ b/Samples/Aggregates/index.ts
@@ -8,17 +8,21 @@ import { DishPrepared } from './DishPrepared';
 import { DishHandler } from './DishHandler';
 import { Kitchen } from './Kitchen';
 
-const client = Client
-    .forMicroservice('f39b1f61-d360-4675-b859-53c05c87c0e6')
-    .withEventTypes(eventTypes =>
-        eventTypes.register(DishPrepared))
-    .withEventHandlers(builder =>
-        builder.register(DishHandler))
-    .build();
+(async () => {
 
-client
-    .aggregateOf(Kitchen,'bfe6f6e4-ada2-4344-8a3b-65a3e1fe16e9',_  => _.forTenant(TenantId.development))
-    .perform(kitchen => kitchen.prepareDish('Bean Blaster Taco', 'Mr. Taco'));
 
-console.log('Done');
+    const client = Client
+        .forMicroservice('f39b1f61-d360-4675-b859-53c05c87c0e6')
+        .withEventTypes(eventTypes =>
+            eventTypes.register(DishPrepared))
+        .withEventHandlers(builder =>
+            builder.register(DishHandler))
+        .build();
 
+    await client
+        .aggregateOf(Kitchen, 'bfe6f6e4-ada2-4344-8a3b-65a3e1fe16e9', _ => _.forTenant(TenantId.development))
+        .perform(kitchen => kitchen.prepareDish('Bean Blaster Taco', 'Mr. Taco'));
+
+    console.log('Done');
+
+})();

--- a/Samples/Aggregates/package.json
+++ b/Samples/Aggregates/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "samples.aggregates",
+    "private": true,
+    "version": "14.1.0",
+    "main": "index.js",
+    "author": "Dolittle",
+    "license": "MIT",
+    "scripts": {
+        "watch": "nodemon --watch **/*.ts --exec 'ts-node' index.ts",
+        "start": "ts-node index.ts",
+        "build": "tsc -b ./tsconfig.json"
+    },
+    "dependencies": {
+        "@dolittle/sdk": "14.1.0",
+        "@dolittle/sdk.aggregates": "14.1.0",
+        "@dolittle/sdk.artifacts": "14.1.0",
+        "@dolittle/sdk.events": "14.1.0",
+        "@dolittle/sdk.events.handling": "14.1.0"
+    },
+    "devDependencies": {
+        "nodemon": "^2.0.4",
+        "ts-node": "^8.10.1"
+    }
+}

--- a/Samples/Aggregates/tsconfig.json
+++ b/Samples/Aggregates/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../../tsconfig.settings.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "sourceRoot": "../",
+        "inlineSourceMap": true,
+        "sourceMap": false,
+        "outDir": "Distribution"
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["node_modules", "Distribution"],
+    "references": [
+        { "path": "../../Source/sdk" }
+    ]
+}

--- a/Samples/Environment/docker-compose.yml
+++ b/Samples/Environment/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       driver: none
  
   runtime-basic:
-    image: dolittle/runtime:5.0.2
+    image: dolittle/runtime:5.3.5
     volumes:
       - ${PWD}/resources-basic.json:/app/.dolittle/resources.json
       - ${PWD}/tenants.json:/app/.dolittle/tenants.json
@@ -24,7 +24,7 @@ services:
       - 50053:50053
 
   runtime-eventhorizon:
-    image: dolittle/runtime:5.0.2
+    image: dolittle/runtime:5.3.5
     volumes:
       - ${PWD}/resources-eventhorizon.json:/app/.dolittle/resources.json
       - ${PWD}/tenants.json:/app/.dolittle/tenants.json

--- a/Samples/tsconfig.json
+++ b/Samples/tsconfig.json
@@ -2,6 +2,7 @@
     "files": [],
     "include": [],
     "references": [
+        { "path": "./Aggregates" },
         { "path": "./Kitchen" },
         { "path": "./Container" },
         { "path": "./EventHorizon" }

--- a/Source/aggregates/.eslintignore
+++ b/Source/aggregates/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+Distribution
+wallaby.conf.js

--- a/Source/aggregates/AggregateOf.ts
+++ b/Source/aggregates/AggregateOf.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommittedAggregateEvents, EventSourceId, IEventStore } from '@dolittle/sdk.events';
+import { IAggregateOf } from './IAggregateOf';
+import { IAggregateRootOperations } from './IAggregateRootOperations';
+import { IEventTypes } from '@dolittle/sdk.artifacts';
+import { Logger } from 'winston';
+import { Constructor } from '@dolittle/types';
+import { AggregateRootOperations } from './AggregateRootOperations';
+import { AggregateRoot } from './AggregateRoot';
+import { AggregateRootDecoratedTypes } from './AggregateRootDecoratedTypes';
+
+/**
+ * Represents an implementation of {@link IAggregateOf<TAggregateRoot>}.
+ * @template TAggregateRoot
+ */
+export class AggregateOf<TAggregateRoot extends AggregateRoot> implements IAggregateOf<TAggregateRoot> {
+
+    constructor(
+        private readonly _type: Constructor<TAggregateRoot>,
+        private readonly _eventStore: IEventStore,
+        private readonly _eventTypes: IEventTypes,
+        private readonly _logger: Logger) {
+    }
+
+    /** @inheritdoc */
+    create(): IAggregateRootOperations<TAggregateRoot> {
+        return this.get(EventSourceId.new());
+    }
+
+    /** @inheritdoc */
+    get(eventSourceId: EventSourceId): IAggregateRootOperations<TAggregateRoot> {
+        const aggregateRoot = new this._type(eventSourceId);
+        this.reApplyEvents(aggregateRoot);
+        const operations = new AggregateRootOperations<TAggregateRoot>(
+            this._type,
+            this._eventStore,
+            aggregateRoot,
+            this._eventTypes,
+            this._logger);
+        return operations;
+    }
+
+    private reApplyEvents(aggregateRoot: TAggregateRoot) {
+        const eventSourceId = aggregateRoot.eventSourceId;
+        const aggregateRootId = AggregateRootDecoratedTypes.getFor(this._type).aggregateRootId;
+        aggregateRoot.aggregateRootId = aggregateRootId;
+
+        this._logger.debug(
+            `Re-applying events for ${this._type.name} with aggregate root id ${aggregateRootId} with event source id ${eventSourceId}`,
+            this._type,
+            aggregateRootId,
+            eventSourceId
+        );
+
+        //throw new Error('Not implemented');
+        /*
+        const committedEvents: CommittedAggregateEvents = this._eventStore.fetchForAggregate(aggregateRootId, eventSourceId);
+        if (committedEvents.hasEvents) {
+            this._logger.silly(`Re-applying ${committedEvents.length}`, committedEvents.length);
+            aggregateRoot.reApply(committedEvents);
+        } else {
+            this._logger.silly('No events to re-apply');
+        }*/
+    }
+}

--- a/Source/aggregates/AggregateOf.ts
+++ b/Source/aggregates/AggregateOf.ts
@@ -1,15 +1,18 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { CommittedAggregateEvents, EventSourceId, IEventStore } from '@dolittle/sdk.events';
+import { AggregateRootVersionIsOutOfOrder, CommittedAggregateEvent, CommittedAggregateEvents, EventSourceId, EventWasAppliedByOtherAggregateRoot, EventWasAppliedToOtherEventSource, IEventStore } from '@dolittle/sdk.events';
 import { IAggregateOf } from './IAggregateOf';
 import { IAggregateRootOperations } from './IAggregateRootOperations';
-import { IEventTypes } from '@dolittle/sdk.artifacts';
+import { EventTypeId, IEventTypes } from '@dolittle/sdk.artifacts';
 import { Logger } from 'winston';
 import { Constructor } from '@dolittle/types';
 import { AggregateRootOperations } from './AggregateRootOperations';
 import { AggregateRoot } from './AggregateRoot';
 import { AggregateRootDecoratedTypes } from './AggregateRootDecoratedTypes';
+import { OnDecoratedMethods } from './OnDecoratedMethods';
+import { OnDecoratedMethod } from './OnDecoratedMethod';
+import { Guid } from '@dolittle/rudiments';
 
 /**
  * Represents an implementation of {@link IAggregateOf<TAggregateRoot>}.
@@ -57,9 +60,57 @@ export class AggregateOf<TAggregateRoot extends AggregateRoot> implements IAggre
         const committedEvents = this._eventStore.fetchForAggregate(aggregateRootId, eventSourceId);
         if (committedEvents.hasEvents) {
             this._logger.silly(`Re-applying ${committedEvents.length}`, committedEvents.length);
-            aggregateRoot.reApply(committedEvents);
+
+            this.throwIfEventWasAppliedToOtherEventSource(aggregateRoot, committedEvents);
+            this.throwIfEventWasAppliedByOtherAggreateRoot(aggregateRoot, committedEvents);
+
+            let onMethods: OnDecoratedMethod[] = [];
+            const hasState = OnDecoratedMethods.methodsPerAggregate.has(this._type);
+            if (hasState) {
+                onMethods = OnDecoratedMethods.methodsPerAggregate.get(this._type)!;
+            }
+
+            for (const event of committedEvents) {
+                this.throwIfAggregateRootVersionIsOutOfOrder(aggregateRoot, event);
+                aggregateRoot.nextVersion();
+                if (hasState) {
+                    const onMethod = onMethods.find(_ => {
+                        let eventTypeId = EventTypeId.from(Guid.empty);
+                        if (_.eventTypeOrId instanceof Function) {
+                            eventTypeId = this._eventTypes.getFor(_.eventTypeOrId).id;
+                        } else {
+                            eventTypeId = EventTypeId.from(_.eventTypeOrId);
+                        }
+
+                        return eventTypeId.equals(event.type.id);
+                    });
+
+                    if (onMethod) {
+                        onMethod.method(event.content);
+                    }
+                }
+            }
         } else {
             this._logger.silly('No events to re-apply');
         }
     }
+
+    private throwIfAggregateRootVersionIsOutOfOrder(aggregateRoot: AggregateRoot, event: CommittedAggregateEvent) {
+        if (event.aggregateRootVersion.value !== aggregateRoot.version.value) {
+            throw new AggregateRootVersionIsOutOfOrder(event.aggregateRootVersion, aggregateRoot.version);
+        }
+    }
+
+    private throwIfEventWasAppliedByOtherAggreateRoot(aggregateRoot: AggregateRoot, event: CommittedAggregateEvents) {
+        if (!event.aggregateRootId.equals(aggregateRoot.aggregateRootId)) {
+            throw new EventWasAppliedByOtherAggregateRoot(event.aggregateRootId, aggregateRoot.aggregateRootId);
+        }
+    }
+
+    private throwIfEventWasAppliedToOtherEventSource(aggregateRoot: AggregateRoot, event: CommittedAggregateEvents) {
+        if (!event.eventSourceId.equals(aggregateRoot.eventSourceId)) {
+            throw new EventWasAppliedToOtherEventSource(event.eventSourceId, aggregateRoot.eventSourceId);
+        }
+    }
+
 }

--- a/Source/aggregates/AggregateOf.ts
+++ b/Source/aggregates/AggregateOf.ts
@@ -54,14 +54,12 @@ export class AggregateOf<TAggregateRoot extends AggregateRoot> implements IAggre
             eventSourceId
         );
 
-        //throw new Error('Not implemented');
-        /*
-        const committedEvents: CommittedAggregateEvents = this._eventStore.fetchForAggregate(aggregateRootId, eventSourceId);
+        const committedEvents = this._eventStore.fetchForAggregate(aggregateRootId, eventSourceId);
         if (committedEvents.hasEvents) {
             this._logger.silly(`Re-applying ${committedEvents.length}`, committedEvents.length);
             aggregateRoot.reApply(committedEvents);
         } else {
             this._logger.silly('No events to re-apply');
-        }*/
+        }
     }
 }

--- a/Source/aggregates/AggregateOf.ts
+++ b/Source/aggregates/AggregateOf.ts
@@ -86,7 +86,7 @@ export class AggregateOf<TAggregateRoot extends AggregateRoot> implements IAggre
                     });
 
                     if (onMethod) {
-                        onMethod.method(event.content);
+                        onMethod.method.call(aggregateRoot, event.content);
                     }
                 }
             }

--- a/Source/aggregates/AggregateOf.ts
+++ b/Source/aggregates/AggregateOf.ts
@@ -57,7 +57,7 @@ export class AggregateOf<TAggregateRoot extends AggregateRoot> implements IAggre
             eventSourceId
         );
 
-        const committedEvents = this._eventStore.fetchForAggregate(aggregateRootId, eventSourceId);
+        const committedEvents = this._eventStore.fetchForAggregateSync(aggregateRootId, eventSourceId);
         if (committedEvents.hasEvents) {
             this._logger.silly(`Re-applying ${committedEvents.length}`, committedEvents.length);
 

--- a/Source/aggregates/AggregateRoot.ts
+++ b/Source/aggregates/AggregateRoot.ts
@@ -82,32 +82,12 @@ export class AggregateRoot {
     }
 
     /**
-     * Re apply events from the event store
-     * @param {CommittedAggregateEvents} events Events to re apply.
+     * Move to next version
      */
-    reApply(events: CommittedAggregateEvents) {
-        this.throwIfEventWasAppliedToOtherEventSource(events);
-        this.throwIfEventWasAppliedByOtherAggreateRoot(events);
-
-        for (const event of events) {
-            this.throwIfAggregateRootVersionIsOutOfOrder(event);
-            this._version = this._version.next();
-            if (!this.isStateLess) {
-                this.invokeOnMethod(event);
-            }
-        }
+    nextVersion() {
+        this._version = this._version.next();
     }
 
-    /**
-     * Gets whether aggregate root is stateless or not.
-     */
-    get isStateLess() {
-        return true;
-    }
-
-    private invokeOnMethod(event: CommittedAggregateEvent) {
-
-    }
 
     private applyImplementation(event: any, eventType: EventType, isPublic: boolean) {
         this.throwIfEventContentIsNullOrUndefined(event);
@@ -119,24 +99,6 @@ export class AggregateRoot {
     private throwIfEventContentIsNullOrUndefined(event: any) {
         if (!event) {
             throw new EventContentNeedsToBeDefined();
-        }
-    }
-
-    private throwIfAggregateRootVersionIsOutOfOrder(event: CommittedAggregateEvent) {
-        if (event.aggregateRootVersion.value !== this.version.value) {
-            throw new AggregateRootVersionIsOutOfOrder(event.aggregateRootVersion, this.version);
-        }
-    }
-
-    private throwIfEventWasAppliedByOtherAggreateRoot(event: CommittedAggregateEvents) {
-        if (!event.aggregateRootId.equals(this.aggregateRootId)) {
-            throw new EventWasAppliedByOtherAggregateRoot(event.aggregateRootId, this.aggregateRootId);
-        }
-    }
-
-    private throwIfEventWasAppliedToOtherEventSource(event: CommittedAggregateEvents) {
-        if (!event.eventSourceId.equals(this.eventSourceId)) {
-            throw new EventWasAppliedToOtherEventSource(event.eventSourceId, this.eventSourceId);
         }
     }
 }

--- a/Source/aggregates/AggregateRoot.ts
+++ b/Source/aggregates/AggregateRoot.ts
@@ -1,0 +1,125 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import {
+    AggregateRootId,
+    AggregateRootVersion,
+    AggregateRootVersionIsOutOfOrder,
+    CommittedAggregateEvent,
+    CommittedAggregateEvents,
+    EventContentNeedsToBeDefined,
+    EventSourceId,
+    EventType,
+    EventWasAppliedByOtherAggregateRoot,
+    EventWasAppliedToOtherEventSource
+} from '@dolittle/sdk.events';
+import { AppliedEvent } from './AppliedEvent';
+
+/**
+ * Represents the aggregate root
+ */
+export class AggregateRoot {
+    private _appliedEvents: AppliedEvent[] = [];
+    private _version: AggregateRootVersion = AggregateRootVersion.initial;
+
+    constructor(readonly eventSourceId: EventSourceId) {
+    }
+
+    readonly aggregateRootId!: AggregateRootId;
+
+    /**
+     * Gets the version of the aggregate root
+     * @returns {AggregateRootVersion}
+     */
+    get version(): AggregateRootVersion {
+        return this._version;
+    }
+
+    /**
+     * Gets all applied events
+     * @returns {AppliedEvent[]}
+     */
+    get appliedEvents(): AppliedEvent[] {
+        return this._appliedEvents;
+    }
+
+    /**
+     * Apply an event to the aggregate root that will be committed to the event store
+     * @param {*} event Event type apply.
+     * @param {EventType} [eventType] Optional type of event to apply.
+     */
+    apply(event: any, eventType?: EventType): void {
+        eventType = eventType || EventType.unspecified;
+        this.applyImplementation(event, eventType, false);
+    }
+
+    /**
+     * Apply a public event to the aggregate root that will be committed to the event store
+     * @param {*} event Event type apply.
+     * @param {EventType} [eventType] Optional type of event to apply.
+     */
+    applyPublic(event: any, eventType?: EventType): void {
+        eventType = eventType || EventType.unspecified;
+        this.applyImplementation(event, eventType, false);
+    }
+
+    /**
+     * Re apply events from the event store
+     * @param {CommittedAggregateEvents} events Events to re apply.
+     */
+    reApply(events: CommittedAggregateEvents) {
+        this.throwIfEventWasAppliedToOtherEventSource(events);
+        this.throwIfEventWasAppliedByOtherAggreateRoot(events);
+
+        for (const event of events) {
+            this.throwIfAggregateRootVersionIsOutOfOrder(event);
+            this._version = this._version.next();
+            if (!this.isStateLess) {
+                this.invokeOnMethod(event);
+            }
+        }
+    }
+
+    /**
+     * Gets whether aggregate root is stateless or not.
+     */
+    get isStateLess() {
+        return true;
+    }
+
+    private invokeOnMethod(event: CommittedAggregateEvent) {
+
+    }
+
+    private applyImplementation(event: any, eventType: EventType, isPublic: boolean) {
+        this.throwIfEventContentIsNullOrUndefined(event);
+        this._appliedEvents.push(new AppliedEvent(event, eventType, isPublic));
+
+        this._version = this._version.next();
+    }
+
+    private throwIfEventContentIsNullOrUndefined(event: any) {
+        if (!event) {
+            throw new EventContentNeedsToBeDefined();
+        }
+    }
+
+    private throwIfAggregateRootVersionIsOutOfOrder(event: CommittedAggregateEvent) {
+        if (event.aggregateRootVersion.value !== this.version.value) {
+            throw new AggregateRootVersionIsOutOfOrder(event.aggregateRootVersion, this.version);
+        }
+    }
+
+    private throwIfEventWasAppliedByOtherAggreateRoot(event: CommittedAggregateEvents) {
+        if (!event.aggregateRootId.equals(this.aggregateRootId)) {
+            throw new EventWasAppliedByOtherAggregateRoot(event.aggregateRootId, this.aggregateRootId);
+        }
+    }
+
+    private throwIfEventWasAppliedToOtherEventSource(event: CommittedAggregateEvents) {
+        if (!event.eventSourceId.equals(this.eventSourceId)) {
+            throw new EventWasAppliedToOtherEventSource(event.eventSourceId, this.eventSourceId);
+        }
+    }
+}
+

--- a/Source/aggregates/AggregateRoot.ts
+++ b/Source/aggregates/AggregateRoot.ts
@@ -31,7 +31,7 @@ export class AggregateRoot {
      * Gets aggregate root id
      */
     get aggregateRootId(): AggregateRootId {
-        if (!this.aggregateRootId) {
+        if (!this._aggregateRootId) {
             throw new AggregateRootIdentifierNotSet();
         }
         return this._aggregateRootId!;

--- a/Source/aggregates/AggregateRoot.ts
+++ b/Source/aggregates/AggregateRoot.ts
@@ -13,19 +13,37 @@ import {
     EventWasAppliedByOtherAggregateRoot,
     EventWasAppliedToOtherEventSource
 } from '@dolittle/sdk.events';
+import { AggregateRootIdentifierNotSet } from './AggregateRootIdentifierNotSet';
 import { AppliedEvent } from './AppliedEvent';
 
 /**
  * Represents the aggregate root
  */
 export class AggregateRoot {
+    private _aggregateRootId?: AggregateRootId;
     private _appliedEvents: AppliedEvent[] = [];
     private _version: AggregateRootVersion = AggregateRootVersion.initial;
 
     constructor(readonly eventSourceId: EventSourceId) {
     }
 
-    readonly aggregateRootId!: AggregateRootId;
+    /**
+     * Gets aggregate root id
+     */
+    get aggregateRootId(): AggregateRootId {
+        if (!this.aggregateRootId) {
+            throw new AggregateRootIdentifierNotSet();
+        }
+        return this._aggregateRootId!;
+    }
+
+    /**
+     * Sets the aggregate root id - internal use
+     * @internal
+     */
+    set aggregateRootId(value: AggregateRootId) {
+        this._aggregateRootId = value;
+    }
 
     /**
      * Gets the version of the aggregate root
@@ -122,4 +140,3 @@ export class AggregateRoot {
         }
     }
 }
-

--- a/Source/aggregates/AggregateRootAction.ts
+++ b/Source/aggregates/AggregateRootAction.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+import { AggregateRoot } from './AggregateRoot';
+
+
+export type AggregateRootAction<TAggregate extends AggregateRoot> = (aggregateRoot: TAggregate) => void | Promise<void>;

--- a/Source/aggregates/AggregateRootDecoratedType.ts
+++ b/Source/aggregates/AggregateRootDecoratedType.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { AggregateRootId } from '../events/AggregateRootId';
+import { Constructor } from '@dolittle/types';
+
+/**
+ * Represents an aggregate root created from the decorator.
+ */
+export class AggregateRootDecoratedType {
+    constructor(readonly aggregateRootId: AggregateRootId, readonly type: Constructor<any>) {
+    }
+}

--- a/Source/aggregates/AggregateRootDecoratedType.ts
+++ b/Source/aggregates/AggregateRootDecoratedType.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { AggregateRootId } from '../events/AggregateRootId';
+import { AggregateRootId } from '@dolittle/sdk.events';
 import { Constructor } from '@dolittle/types';
 
 /**

--- a/Source/aggregates/AggregateRootDecoratedTypes.ts
+++ b/Source/aggregates/AggregateRootDecoratedTypes.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '@dolittle/types';
+import { MissingAggregateRootDecoratorFor } from './MissingAggregateRootDecoratorFor';
+import { AggregateRootDecoratedType } from './AggregateRootDecoratedType';
+
+/**
+ * Handles the registrations of @aggregateRoot decorated classes.
+ */
+export class AggregateRootDecoratedTypes {
+    static readonly types: AggregateRootDecoratedType[] = [];
+
+    /**
+     * Get the aggregate root details for a specific type.
+     * @param {Constructor<any>} type Type to get for.
+     * @returns {AggregateRootDecoratedType}
+     */
+    static getFor(type: Constructor<any>): AggregateRootDecoratedType {
+        const decoratedType = this.types.find(_ => _.type === type);
+        if (!decoratedType) {
+            throw new MissingAggregateRootDecoratorFor(type);
+        }
+        return decoratedType;
+    }
+
+    /**
+     * Registers aggregate root decorated type
+     * @param {AggregateRootDecoratedType} aggregateRootDecoratedType Type to register
+     */
+    static register(aggregateRootDecoratedType: AggregateRootDecoratedType) {
+        this.types.push(aggregateRootDecoratedType);
+    }
+}

--- a/Source/aggregates/AggregateRootIdentifierNotSet.ts
+++ b/Source/aggregates/AggregateRootIdentifierNotSet.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * The exception that gets thrown when an aggregate root identifier is not set and is expected
+ */
+export class AggregateRootIdentifierNotSet extends Error {
+    constructor() {
+        super('Aggregate root identifier is not set.');
+    }
+}

--- a/Source/aggregates/AggregateRootOperations.ts
+++ b/Source/aggregates/AggregateRootOperations.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IAggregateRootOperations } from './IAggregateRootOperations';
+import { AggregateRootAction } from './AggregateRootAction';
+import { AggregateRoot } from './AggregateRoot';
+import { AggregateRootVersion, AggregateRootId, CommittedAggregateEvent, CommittedAggregateEvents, IEventStore, UncommittedAggregateEvent } from '@dolittle/sdk.events';
+import { IEventTypes } from '@dolittle/sdk.artifacts';
+import { Logger } from 'winston';
+import { Constructor } from '@dolittle/types';
+
+
+/**
+ * Represents an implementation of {@link IAggregateRootOperations<TAggregate>}
+ * @template TAggregateRoot
+ */
+export class AggregateRootOperations<TAggregateRoot extends AggregateRoot> implements IAggregateRootOperations<TAggregateRoot> {
+    constructor(
+        private readonly _aggregateRootType: Constructor<any>,
+        private readonly _eventStore: IEventStore,
+        private readonly _aggregateRoot: TAggregateRoot,
+        private readonly _eventTypes: IEventTypes,
+        private readonly _logger: Logger) {
+    }
+
+    /** @inheritdoc */
+    async perform(action: AggregateRootAction<TAggregateRoot>): Promise<void> {
+        const aggregateRootId = this._aggregateRoot.aggregateRootId;
+        this._logger.debug(
+            `Performing operation on ${this._aggregateRootType.name} with aggregate root id ${aggregateRootId} applying events to event source ${this._aggregateRoot.eventSourceId}`,
+            this._aggregateRootType,
+            aggregateRootId,
+            this._aggregateRoot.eventSourceId);
+
+        await action(this._aggregateRoot);
+        if (this._aggregateRoot.appliedEvents.length > 0) {
+            await this.commitAppliedEvents(aggregateRootId);
+        }
+    }
+
+    private async commitAppliedEvents(aggregateRootId: AggregateRootId): Promise<CommittedAggregateEvents> {
+
+        this._logger.debug(
+            `${this._aggregateRootType.name} with aggregate root id ${aggregateRootId} is committing ${this._aggregateRoot.appliedEvents.length} events to the event source ${this._aggregateRoot.eventSourceId}`,
+            this._aggregateRootType,
+            aggregateRootId,
+            this._aggregateRoot.appliedEvents.length,
+            this._aggregateRoot.eventSourceId);
+
+        return this._eventStore
+            .forAggregate(aggregateRootId)
+            .withEventSource(this._aggregateRoot.eventSourceId)
+            .expectVersion(AggregateRootVersion.from(this._aggregateRoot.version.value - this._aggregateRoot.appliedEvents.length))
+            .commit(this.getUncommittedAggregateEvents());
+    }
+
+    private getUncommittedAggregateEvents(): UncommittedAggregateEvent[] {
+        return this._aggregateRoot.appliedEvents.map(_ => {
+            const uncommitted: UncommittedAggregateEvent = {
+                content: _.event,
+                eventType: _.hasEventType ? _.eventType : this._eventTypes.getFor(_.event.constructor),
+                public: _.isPublic
+            };
+            return uncommitted;
+        });
+    }
+}

--- a/Source/aggregates/AppliedEvent.ts
+++ b/Source/aggregates/AppliedEvent.ts
@@ -24,6 +24,6 @@ export class AppliedEvent {
      * @returns {Boolean}
      */
     get hasEventType(): boolean {
-        return !this.eventType.id.equals(EventType.unspecified);
+        return !this.eventType.id.equals(EventType.unspecified.id);
     }
 }

--- a/Source/aggregates/AppliedEvent.ts
+++ b/Source/aggregates/AppliedEvent.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { EventType } from '@dolittle/sdk.events';
+
+/**
+ * Represents an uncommitted event that is applied on an aggregate.
+ */
+
+export class AppliedEvent {
+
+    /**
+     * Initializes a new instance of {@link AppliedEvent}.
+     * @param {*} event The event content.
+     * @param {EventType} eventType The {@link EventType}.
+     * @param {boolean} isPublic Whether the event is public or not.
+     */
+    constructor(readonly event: any, readonly eventType: EventType, readonly isPublic: boolean) {
+    }
+
+    /**
+     * Gets whether AppliedEvent has event type explicitly defined or not
+     *
+     * @returns {Boolean}
+     */
+    get hasEventType(): boolean {
+        return !this.eventType.id.equals(EventType.unspecified);
+    }
+}

--- a/Source/aggregates/IAggregateOf.ts
+++ b/Source/aggregates/IAggregateOf.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { EventSourceId } from '@dolittle/sdk.events';
+import { IAggregateRootOperations } from './IAggregateRootOperations';
+import { AggregateRoot } from './AggregateRoot';
+
+/**
+ * Defines a way to work with an {@link AggregateRoot}
+ * @template TAggregate
+ */
+
+export interface IAggregateOf<TAggregate extends AggregateRoot> {
+
+    /**
+     * Create a new {@link AggregateRoot} with a random {@link EventSourceId}
+     * @returns {IAggregateRootOperations<TAggregate>}
+     */
+    create(): IAggregateRootOperations<TAggregate>;
+
+    /**
+     * Gets an {@link AggregateRoot} with a given {@link EventSourceId}
+     * @param {EventSourceId} eventSourceId {@link EventSourceId} of the {@link AggregateRoot}
+     * @returns {IAggregateRootOperations<TAggregate>}
+     */
+    get(eventSourceId: EventSourceId): IAggregateRootOperations<TAggregate>;
+}

--- a/Source/aggregates/IAggregateRootOperations.ts
+++ b/Source/aggregates/IAggregateRootOperations.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { AggregateRootAction } from './AggregateRootAction';
+import { AggregateRoot } from './AggregateRoot';
+
+/**
+ * Defines a system for working with operations that can be formed on an {@link AggregateRoot}.
+ * @template TAggregate {@link AggregateRoot} type
+ */
+
+export interface IAggregateRootOperations<TAggregate extends AggregateRoot> {
+
+    /**
+     * Perform an operation on an {@link AggregateRoot}
+     * @param {AggregateRootAction<TAggregate> action Callback for working with the aggregate root.
+     * @returns {Promise<void>}
+     */
+    perform(action: AggregateRootAction<TAggregate>): Promise<void>;
+}

--- a/Source/aggregates/MissingAggregateRootDecoratorFor.ts
+++ b/Source/aggregates/MissingAggregateRootDecoratorFor.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '@dolittle/types';
+
+/**
+ * Exception that is thrown when missing the aggregate root decorator for a type.
+ */
+export class MissingAggregateRootDecoratorFor extends Error {
+    constructor(type: Constructor<any>) {
+        super(`Missing aggregate root decorator for type '${type.name}'`);
+    }
+}

--- a/Source/aggregates/OnDecoratedMethod.ts
+++ b/Source/aggregates/OnDecoratedMethod.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Guid } from '@dolittle/rudiments';
+import { Constructor } from '@dolittle/types';
+
+import { EventTypeId } from '@dolittle/sdk.artifacts';
+
+import { OnMethodSignature } from './OnMethodSignature';
+
+/**
+ * Represents methods decorated with the on decorator.
+ */
+export class OnDecoratedMethod {
+
+    /**
+     * Initializes a new instance of {@link OnDecoratedMethod}.
+     * @param {Constructor<any>} owner Owner of the method.
+     * @param {Constructor<any> | EventTypeId | Guid | string} eventTypeOrId Type or event type id of event it handles.
+     * @param {number | undefined} generation Generation of the event or undefined.
+     * @param {OnMethodSignature<any>} method The actual method that handles the event.
+     * @param {string} name The name of the method.
+     */
+    constructor(
+        readonly owner: Constructor<any>,
+        readonly eventTypeOrId: Constructor<any> | EventTypeId | Guid | string,
+        readonly generation: number | undefined,
+        readonly method: OnMethodSignature<any>,
+        readonly name: string) {
+    }
+}

--- a/Source/aggregates/OnDecoratedMethods.ts
+++ b/Source/aggregates/OnDecoratedMethods.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Guid } from '@dolittle/rudiments';
+import { Constructor } from '@dolittle/types';
+
+import { EventTypeId } from '@dolittle/sdk.artifacts';
+
+import { OnMethodSignature } from './OnMethodSignature';
+import { OnDecoratedMethod } from './OnDecoratedMethod';
+
+/**
+ * Defines the system that knows about all the methods decorated with the handle decorator.
+ */
+export class OnDecoratedMethods {
+    /**
+     * All handle methods grouped by their event handler.
+     */
+    static readonly methodsPerAggregate: Map<Function, OnDecoratedMethod[]> = new Map();
+
+    /**
+     * Registers handles decorated methods
+     * @param {Constructor<any>} target Target that owns the handle method.
+     * @param {Constructor<any> | EventTypeId | Guid | string} eventTypeOrId Type or event type id of event the handle method is for or the event.
+     * @param {number | undefined} generation Generation of event type or undefined.
+     * @param {EventHandlerSignature<any>} method The handle method.
+     * @param {string} name The name of the method.
+     */
+    static register(
+        target: Constructor<any>,
+        eventTypeOrId: Constructor<any> | EventTypeId | Guid | string,
+        generation: number | undefined,
+        method: OnMethodSignature<any>,
+        name: string): void {
+        let methods = this.methodsPerAggregate.get(target);
+        if (!methods) {
+            this.methodsPerAggregate.set(target, methods = []);
+        }
+        methods.push(new OnDecoratedMethod(target, eventTypeOrId, generation, method, name));
+    }
+}

--- a/Source/aggregates/OnMethodSignature.ts
+++ b/Source/aggregates/OnMethodSignature.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Represents the signature for an on method.
+ */
+export type OnMethodSignature<T = any> = (event: T) => void | Promise<void>;

--- a/Source/aggregates/aggregateRootDecorator.ts
+++ b/Source/aggregates/aggregateRootDecorator.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Guid } from '@dolittle/rudiments';
-import { AggregateRootId } from '../events/AggregateRootId';
+import { AggregateRootId } from '@dolittle/sdk.events';
 import { AggregateRootDecoratedType } from './AggregateRootDecoratedType';
 import { AggregateRootDecoratedTypes } from './AggregateRootDecoratedTypes';
 

--- a/Source/aggregates/aggregateRootDecorator.ts
+++ b/Source/aggregates/aggregateRootDecorator.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Guid } from '@dolittle/rudiments';
+import { AggregateRootId } from '../events/AggregateRootId';
+import { AggregateRootDecoratedType } from './AggregateRootDecoratedType';
+import { AggregateRootDecoratedTypes } from './AggregateRootDecoratedTypes';
+
+/**
+ * Decorator to mark a class as an aggregate root
+ * @param {AggregateRootId | Guid | string} aggregateRootId The identifier of the aggregate root.
+ */
+export function aggregateRoot(aggregateRootId: AggregateRootId | Guid | string) {
+    return function (target: any) {
+        AggregateRootDecoratedTypes.register(
+            new AggregateRootDecoratedType(
+                AggregateRootId.from(aggregateRootId),
+                target));
+    };
+}

--- a/Source/aggregates/for_Dummy/when_nothing.ts
+++ b/Source/aggregates/for_Dummy/when_nothing.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+describe('when nothing', () => {
+    it('should be fine', () => true.should.be.true);
+});

--- a/Source/aggregates/index.ts
+++ b/Source/aggregates/index.ts
@@ -1,14 +1,19 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+export * from './AggregateOf';
 export * from './AggregateRoot';
+export * from './AggregateRootAction';
 export * from './AggregateRootDecoratedType';
 export * from './AggregateRootDecoratedTypes';
 export * from './aggregateRootDecorator';
+export * from './AggregateRootIdentifierNotSet';
+export * from './AggregateRootOperations';
 export * from './AppliedEvent';
 export * from './MissingAggregateRootDecoratorFor';
 export * from './onDecorator';
 export * from './OnDecoratedMethod';
 export * from './OnDecoratedMethods';
 export * from './OnMethodSignature';
-
+export * from './IAggregateOf';
+export * from './IAggregateRootOperations';

--- a/Source/aggregates/index.ts
+++ b/Source/aggregates/index.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export * from './AggregateRoot';
+export * from './AggregateRootDecoratedType';
+export * from './AggregateRootDecoratedTypes';
+export * from './aggregateRootDecorator';
+export * from './AppliedEvent';
+export * from './MissingAggregateRootDecoratorFor';
+export * from './onDecorator';
+export * from './OnDecoratedMethod';
+export * from './OnDecoratedMethods';
+export * from './OnMethodSignature';
+

--- a/Source/aggregates/onDecorator.ts
+++ b/Source/aggregates/onDecorator.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Guid } from '@dolittle/rudiments';
+import { Constructor } from '@dolittle/types';
+
+import { EventTypeId } from '@dolittle/sdk.artifacts';
+
+import { OnDecoratedMethods } from './OnDecoratedMethods';
+
+/**
+ * Decorator for decorating handle methods.
+ */
+export function on(typeOrId: Constructor<any> | EventTypeId | Guid | string, generation?: number) {
+    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+        OnDecoratedMethods.register(target.constructor, typeOrId, generation, descriptor.value, propertyKey);
+    };
+}

--- a/Source/aggregates/package.json
+++ b/Source/aggregates/package.json
@@ -1,0 +1,43 @@
+{
+    "name": "@dolittle/sdk.aggregates",
+    "version": "14.1.0",
+    "description": "",
+    "author": "",
+    "license": "MIT",
+    "publishConfig": {
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dolittle/Javascript.SDK.git"
+    },
+    "bugs": {
+        "url": "https://github.com/dolittle/Javascript.SDK/issues"
+    },
+    "homepage": "https://github.com/dolittle/Javascript.SDK#readme",
+    "files": [
+        "Distribution",
+        "**/*.ts"
+    ],
+    "main": "Distribution/index.js",
+    "types": "Distribution/index.d.ts",
+    "scripts": {
+        "prebuild": "yarn clean",
+        "postbuild": "yarn lint",
+        "build": "tsc -b",
+        "clean": "gulp clean --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js",
+        "test": "yarn build && yarn test:run",
+        "test:run": "gulp test-run --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js",
+        "test:clean": "gulp test-clean --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js",
+        "lint": "gulp lint --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js",
+        "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
+    },
+    "dependencies": {
+        "@dolittle/concepts": "5.0.1",
+        "@dolittle/rudiments": "5.0.1",
+        "@dolittle/sdk.events": "14.1.0",
+        "@dolittle/sdk.artifacts": "14.1.0"
+    },
+    "devDependencies": {
+    }
+}

--- a/Source/aggregates/tsconfig.json
+++ b/Source/aggregates/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../../tsconfig.settings.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "sourceRoot": "../",
+        "outDir": "Distribution"
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["node_modules", "Distribution"],
+    "references": [
+        { "path": "../artifacts" },
+        { "path": "../events" }
+    ]
+}

--- a/Source/artifacts/EventType.ts
+++ b/Source/artifacts/EventType.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { Guid } from '@dolittle/rudiments';
 import { EventTypeId } from './EventTypeId';
 import { Generation } from './Generation';
 
@@ -11,6 +12,17 @@ import { Generation } from './Generation';
  * @class EventType
  */
 export class EventType {
+
+    /**
+     * Represents an unspecified {@link EventType}
+     */
+    static readonly unspecified: EventType = new EventType(EventTypeId.from(Guid.empty));
+
+    /**
+     * Initializes a new instance of {@link EventType}
+     * @param {EventTypeId} id The unique identifier of the event type.
+     * @param {Generation} [generation] Optional generation - will default to {@link generation.first}
+     */
     constructor(readonly id: EventTypeId, readonly generation: Generation = Generation.first) {
     }
 

--- a/Source/events/AggregateRootId.ts
+++ b/Source/events/AggregateRootId.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Guid } from '@dolittle/rudiments';
+import { ConceptAs } from '@dolittle/concepts';
+
+/**
+ * Represents the unique identifier of an event type.
+ *
+ * @export
+ * @class AggregateRootId
+ * @extends {ConceptAs<Guid, '@dolittle/sdk.events.AggregateRootId'>}
+ */
+export class AggregateRootId extends ConceptAs<Guid, '@dolittle/sdk.events.AggregateRootId'> {
+    constructor(id: Guid) {
+        super(id, '@dolittle/sdk.events.AggregateRootId');
+    }
+    /**
+     * Creates an {@link AggregateRootId} from a guid.
+     *
+     * @static
+     * @param {(Guid | string)} id
+     * @returns {EventSourceId}
+     */
+    static from(id: Guid | string | AggregateRootId): AggregateRootId {
+        if (id instanceof AggregateRootId) return id;
+        return new AggregateRootId(Guid.as(id));
+    }
+};

--- a/Source/events/AggregateRootVersion.ts
+++ b/Source/events/AggregateRootVersion.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ConceptAs } from '@dolittle/concepts';
+
+/**
+ * Represents a version of an aggregate root as a natural number, corresponding to the number of events the Aggregate Root has applied to an Event Source.
+ */
+
+export class AggregateRootVersion extends ConceptAs<number, '@dolittle/sdk.aggregates.AggregateRoot'> {
+
+    /**
+     * The initial version of an aggregate root that has applied no events.
+     */
+    static initial: AggregateRootVersion = AggregateRootVersion.from(0);
+
+    /**
+     * Initializes an instance of {@link AggregateRootVersion}.
+     * @param {number} value The version number.
+     */
+    constructor(value: number) {
+        super(value, '@dolittle/sdk.aggregates.AggregateRoot');
+    }
+
+    /**
+     * Get the next version number
+     * @returns {AggregateRootVersion}
+     */
+    next(): AggregateRootVersion {
+        return new AggregateRootVersion(this.value + 1);
+    }
+
+    /**
+     * Creates an {@link AggregateRootVersion} from a number or existing {@link AggregateRootVersion}
+     *
+     * @static
+     * @param {number | AggregateRootVersion} value The version to create from
+     * @returns {AggregateRootVersion}
+     */
+    static from(value: number | AggregateRootVersion): AggregateRootVersion {
+        return new AggregateRootVersion(value instanceof AggregateRootVersion ? value.value : value);
+    }
+}

--- a/Source/events/AggregateRootVersionIsOutOfOrder.ts
+++ b/Source/events/AggregateRootVersionIsOutOfOrder.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { AggregateRootVersion } from './AggregateRootVersion';
+
+/**
+ * The exception that gets thrown when a sequence of events are not valid for the Aggregate Root it is being used with.
+ */
+
+export class AggregateRootVersionIsOutOfOrder extends Error {
+
+    /**
+     * Initializes a new instance of {@link AggregateRootVersionIsOutOfOrder}.
+     * @param {AggregateRootVersion} version The attempted version number.
+     * @param {AggregateRootVersion} expectedVersion The expected version number.
+     */
+    constructor(version: AggregateRootVersion, expectedVersion: AggregateRootVersion) {
+        super(`Aggregate Root Version is out of order. Version '${version}' does not match '${expectedVersion}'.`);
+    }
+}

--- a/Source/events/CommitAggregateEventsResult.ts
+++ b/Source/events/CommitAggregateEventsResult.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Failure } from '@dolittle/sdk.protobuf';
+import { CommittedAggregateEvents } from './CommittedAggregateEvents';
+
+/**
+ * Represents the result from a commit of events
+ */
+export class CommitAggregateEventsResult {
+
+    /**
+     * Initializes a new instance of {@link CommitEventsResult}
+     * @param {CommittedAggregateEvents} events Events committed.
+     * @param {Failure} failure Failure from the response.
+     */
+    constructor(readonly events: CommittedAggregateEvents, readonly failure?: Failure) {
+    }
+
+    /**
+     * Gets whether or not the commit has failed.
+     */
+    get failed() {
+        return !!this.failure;
+    }
+}

--- a/Source/events/CommitForAggregateBuilder.ts
+++ b/Source/events/CommitForAggregateBuilder.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IEventTypes } from '@dolittle/sdk.artifacts';
+import { Logger } from 'winston';
+import { AggregateRootId } from './AggregateRootId';
+import { IEventStore } from './IEventStore';
+import { EventSourceId } from './EventSourceId';
+import { EventBuilderMethodAlreadyCalled } from './EventBuilderMethodAlreadyCalled';
+import { CommitForAggregateWithEventSourceBuilder } from './CommitForAggregateWithEventSourceBuilder';
+
+/**
+ * Represents the builder for an aggregate event commit
+ */
+export class CommitForAggregateBuilder {
+    private _builder?: CommitForAggregateWithEventSourceBuilder;
+
+    constructor(
+        private readonly _eventStore: IEventStore,
+        private readonly _eventTypes: IEventTypes,
+        private readonly _aggregateRootId: AggregateRootId,
+        private readonly _logger: Logger) {
+    }
+
+    /**
+     * Build aggregate events with event source id
+     * @param {EventSourceId} eventSourceId The {@link EventSourceId}
+     * @returns {CommitForAggregateWithEventSourceBuilder} for continuation.
+     */
+    withEventSource(eventSourceId: EventSourceId): CommitForAggregateWithEventSourceBuilder {
+        if (this._builder) {
+            throw new EventBuilderMethodAlreadyCalled('withEventSource');
+        }
+        this._builder = new CommitForAggregateWithEventSourceBuilder(
+            this._eventStore,
+            this._eventTypes,
+            this._aggregateRootId,
+            eventSourceId,
+            this._logger
+        );
+        return this._builder;
+    }
+}
+
+

--- a/Source/events/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.ts
+++ b/Source/events/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.ts
@@ -9,6 +9,7 @@ import { EventSourceId } from './EventSourceId';
 import { AggregateRootVersion } from './AggregateRootVersion';
 import { CommittedAggregateEvents } from './CommittedAggregateEvents';
 import { UncommittedAggregateEvent } from './UncommittedAggregateEvent';
+import { UncommittedAggregateEvents } from './UncommittedAggregateEvents';
 
 /**
  * Represents the builder for an aggregate event commit
@@ -23,7 +24,19 @@ export class CommitForAggregateWithEventSourceAndExpectedVersionBuilder {
         private readonly _logger: Logger) {
     }
 
+    /**
+     * Commits uncommitted aggregate events to the Event Store
+     * @param {UncommittedAggregateEvent[]} uncommittedEvents Uncommitted events.
+     * @returns {Promise<CommittedAggregateEvents>}
+     */
     async commit(uncommittedEvents: UncommittedAggregateEvent[]): Promise<CommittedAggregateEvents> {
+        const uncommittedAggregateEvents = new UncommittedAggregateEvents(
+            this._eventSourceId,
+            this._aggregateRootId,
+            this._expectedVersion
+        );
+        uncommittedEvents.forEach(_ => uncommittedAggregateEvents.add(_));
+        this._eventStore.commitForAggregate(uncommittedAggregateEvents);
         return new CommittedAggregateEvents(this._eventSourceId, this._aggregateRootId, ...[]);
     }
 }

--- a/Source/events/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.ts
+++ b/Source/events/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IEventTypes } from '@dolittle/sdk.artifacts';
+import { Logger } from 'winston';
+import { AggregateRootId } from './AggregateRootId';
+import { IEventStore } from './IEventStore';
+import { EventSourceId } from './EventSourceId';
+import { AggregateRootVersion } from './AggregateRootVersion';
+import { CommittedAggregateEvents } from './CommittedAggregateEvents';
+import { UncommittedAggregateEvent } from './UncommittedAggregateEvent';
+
+/**
+ * Represents the builder for an aggregate event commit
+ */
+export class CommitForAggregateWithEventSourceAndExpectedVersionBuilder {
+    constructor(
+        private readonly _eventStore: IEventStore,
+        private readonly _eventTypes: IEventTypes,
+        private readonly _aggregateRootId: AggregateRootId,
+        private readonly _eventSourceId: EventSourceId,
+        private readonly _expectedVersion: AggregateRootVersion,
+        private readonly _logger: Logger) {
+    }
+
+    async commit(uncommittedEvents: UncommittedAggregateEvent[]): Promise<CommittedAggregateEvents> {
+        throw new Error('Not implemented');
+    }
+}
+

--- a/Source/events/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.ts
+++ b/Source/events/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.ts
@@ -24,7 +24,7 @@ export class CommitForAggregateWithEventSourceAndExpectedVersionBuilder {
     }
 
     async commit(uncommittedEvents: UncommittedAggregateEvent[]): Promise<CommittedAggregateEvents> {
-        throw new Error('Not implemented');
+        return new CommittedAggregateEvents(this._eventSourceId, this._aggregateRootId, ...[]);
     }
 }
 

--- a/Source/events/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.ts
+++ b/Source/events/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.ts
@@ -36,8 +36,8 @@ export class CommitForAggregateWithEventSourceAndExpectedVersionBuilder {
             this._expectedVersion
         );
         uncommittedEvents.forEach(_ => uncommittedAggregateEvents.add(_));
-        this._eventStore.commitForAggregate(uncommittedAggregateEvents);
-        return new CommittedAggregateEvents(this._eventSourceId, this._aggregateRootId, ...[]);
+        const result = await this._eventStore.commitForAggregate(uncommittedAggregateEvents);
+        return result.events;
     }
 }
 

--- a/Source/events/CommitForAggregateWithEventSourceBuilder.ts
+++ b/Source/events/CommitForAggregateWithEventSourceBuilder.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IEventTypes } from '@dolittle/sdk.artifacts';
+import { Logger } from 'winston';
+import { AggregateRootId } from './AggregateRootId';
+import { IEventStore } from './IEventStore';
+import { EventSourceId } from './EventSourceId';
+import { EventBuilderMethodAlreadyCalled } from './EventBuilderMethodAlreadyCalled';
+import { AggregateRootVersion } from './AggregateRootVersion';
+import { CommitForAggregateWithEventSourceAndExpectedVersionBuilder } from './CommitForAggregateWithEventSourceAndExpectedVersionBuilder';
+
+/**
+ * Represents the builder for an aggregate event commit
+ */
+export class CommitForAggregateWithEventSourceBuilder {
+    private _builder?: CommitForAggregateWithEventSourceAndExpectedVersionBuilder;
+
+    constructor(
+        private readonly _eventStore: IEventStore,
+        private readonly _eventTypes: IEventTypes,
+        private readonly _aggregateRootId: AggregateRootId,
+        private readonly _eventSourceId: EventSourceId,
+        private readonly _logger: Logger) {
+    }
+
+    /**
+     * Configure the expected {@link AggregateRootVersion} for the {@link UncommittedAggregateEvents}.
+     * @param {AggregateRootVersion} expectedVersion Expected {@link AggregateRootVersion}.
+     * @returns  {CommitForAggregateWithEventSourceAndExpectedVersionBuilder}
+     */
+    expectVersion(expectedVersion: AggregateRootVersion): CommitForAggregateWithEventSourceAndExpectedVersionBuilder {
+        if (this._builder) {
+            throw new EventBuilderMethodAlreadyCalled('expectVersion');
+        }
+        this._builder = new CommitForAggregateWithEventSourceAndExpectedVersionBuilder(
+            this._eventStore,
+            this._eventTypes,
+            this._aggregateRootId,
+            this._eventSourceId,
+            expectedVersion,
+            this._logger
+        );
+        return this._builder;
+    }
+}

--- a/Source/events/CommittedAggregateEvent.ts
+++ b/Source/events/CommittedAggregateEvent.ts
@@ -38,10 +38,7 @@ export class CommittedAggregateEvent extends CommittedEvent {
         readonly executionContext: ExecutionContext,
         readonly type: EventType,
         readonly content: any,
-        readonly isPublic: boolean,
-        readonly isExternal: boolean,
-        readonly externalEventLogSequenceNumber: EventLogSequenceNumber,
-        readonly externalEventReceived: DateTime) {
+        readonly isPublic: boolean) {
 
         super(
             eventLogSequenceNumber,
@@ -51,9 +48,9 @@ export class CommittedAggregateEvent extends CommittedEvent {
             type,
             content,
             isPublic,
-            isExternal,
-            externalEventLogSequenceNumber,
-            externalEventReceived);
+            false,
+            EventLogSequenceNumber.first,
+            new DateTime());
     }
 }
 

--- a/Source/events/CommittedAggregateEvent.ts
+++ b/Source/events/CommittedAggregateEvent.ts
@@ -50,7 +50,7 @@ export class CommittedAggregateEvent extends CommittedEvent {
             isPublic,
             false,
             EventLogSequenceNumber.first,
-            new DateTime());
+            DateTime.fromJSDate(new Date()));
     }
 }
 

--- a/Source/events/CommittedAggregateEvent.ts
+++ b/Source/events/CommittedAggregateEvent.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { DateTime } from 'luxon';
+import { EventType } from '@dolittle/sdk.artifacts';
+import { ExecutionContext } from '@dolittle/sdk.execution';
+import { EventSourceId } from './EventSourceId';
+import { EventLogSequenceNumber } from './EventLogSequenceNumber';
+import { AggregateRootId } from './AggregateRootId';
+import { AggregateRootVersion } from './AggregateRootVersion';
+import { CommittedEvent } from './CommittedEvent';
+
+/**
+ * Represents an event that was applied to an Event Source by an Aggregate Root and is committed to the Event Store.
+ */
+export class CommittedAggregateEvent extends CommittedEvent {
+    /**
+     * Initializes a new instance of {@link CommittedEvent}.
+     * @param {EventLogSequenceNumber} eventLogSequenceNumber The sequence number in the event log.
+     * @param {DateTime} occurred Timestamp for when it occurred.
+     * @param {EventSourceId} eventSourceId Identifier of the event source.
+     * @param {AggregateRootId} aggregateRootId Identifier of the aggregate root.
+     * @param {AggregateRootVersion} aggregateRootVersion The version of the aggregate root that applied the event.
+     * @param {ExecutionContext} executionContext The execution context in which the event happened.
+     * @param {EventType} type Type of event.
+     * @param {*} content Actual content of the event.
+     * @param {boolean} isPublic Whether or not the event is a public event.
+     * @param {boolean} isExternal Whether or not the event is originating externally.
+     * @param {number} externalEventLogSequenceNumber If external; the external event log sequence number.
+     * @param {DateTime} externalEventReceived If external; timestamp for when it was received.
+     */
+    constructor(
+        readonly eventLogSequenceNumber: EventLogSequenceNumber,
+        readonly occurred: DateTime,
+        readonly eventSourceId: EventSourceId,
+        readonly aggregateRootId: AggregateRootId,
+        readonly aggregateRootVersion: AggregateRootVersion,
+        readonly executionContext: ExecutionContext,
+        readonly type: EventType,
+        readonly content: any,
+        readonly isPublic: boolean,
+        readonly isExternal: boolean,
+        readonly externalEventLogSequenceNumber: EventLogSequenceNumber,
+        readonly externalEventReceived: DateTime) {
+
+        super(
+            eventLogSequenceNumber,
+            occurred,
+            eventSourceId,
+            executionContext,
+            type,
+            content,
+            isPublic,
+            isExternal,
+            externalEventLogSequenceNumber,
+            externalEventReceived);
+    }
+
+}

--- a/Source/events/CommittedAggregateEvent.ts
+++ b/Source/events/CommittedAggregateEvent.ts
@@ -55,5 +55,5 @@ export class CommittedAggregateEvent extends CommittedEvent {
             externalEventLogSequenceNumber,
             externalEventReceived);
     }
-
 }
+

--- a/Source/events/CommittedAggregateEvents.ts
+++ b/Source/events/CommittedAggregateEvents.ts
@@ -22,7 +22,7 @@ export class CommittedAggregateEvents implements Iterable<CommittedAggregateEven
     private _nextAggregateRootVersion: AggregateRootVersion = AggregateRootVersion.initial;
 
     /**
-     * Creates an instance of {@link CommittedEvents}.
+     * Creates an instance of {@link CommittedAggregateEvents}.
      * @param {...CommittedEvent[]} events Events to initialize with.
      */
     constructor(readonly eventSourceId: EventSourceId, readonly aggregateRootId: AggregateRootId, ...events: CommittedAggregateEvent[]) {

--- a/Source/events/CommittedAggregateEvents.ts
+++ b/Source/events/CommittedAggregateEvents.ts
@@ -1,0 +1,101 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { EventSourceId } from '.';
+import { AggregateRootId } from './AggregateRootId';
+import { CommittedAggregateEvent } from './CommittedAggregateEvent';
+import { CommittedEvent } from './CommittedEvent';
+import { AggregateRootVersion } from './AggregateRootVersion';
+import { EventLogSequenceNumberIsOutOfOrder } from './EventLogSequenceNumberIsOutOfOrder';
+import { AggregateRootVersionIsOutOfOrder } from './AggregateRootVersionIsOutOfOrder';
+import { EventWasAppliedByOtherAggregateRoot } from './EventWasAppliedByOtherAggregateRoot';
+import { EventWasAppliedToOtherEventSource } from './EventWasAppliedToOtherEventSource';
+import { EventContentNeedsToBeDefined } from './EventContentNeedsToBeDefined';
+
+/**
+ * Represents a collection of committed events.
+ *
+ * @summary This type implements Iterable<CommittedEvent> and can be used for iterations directly.
+ */
+export class CommittedAggregateEvents implements Iterable<CommittedAggregateEvent> {
+    private _events: CommittedAggregateEvent[] = [];
+    private _nextAggregateRootVersion: AggregateRootVersion = AggregateRootVersion.initial;
+
+    /**
+     * Creates an instance of {@link CommittedEvents}.
+     * @param {...CommittedEvent[]} events Events to initialize with.
+     */
+    constructor(readonly eventSourceId: EventSourceId, readonly aggregateRootId: AggregateRootId, ...events: CommittedAggregateEvent[]) {
+
+        events.forEach((event, eventIndex) => {
+            if (eventIndex === 0) {
+                this._nextAggregateRootVersion = event.aggregateRootVersion;
+            } else {
+                this.throwIfEventLogVersionIsOutOfOrder(event, events[eventIndex - 1]);
+            }
+
+            this.throwIfEventContentIsNullOrUndefined(event);
+            this.throwIfEventWasAppliedToOtherEventSource(event);
+            this.throwIfEventWasAppliedByOtherAggreateRoot(event);
+            this.throwIfAggregateRootVersionIsOutOfOrder(event);
+        });
+
+        if (events) {
+            this._events = events;
+        }
+    }
+
+    /** @inheritdoc */
+    [Symbol.iterator](): Iterator<CommittedAggregateEvent> {
+        return this._events[Symbol.iterator]();
+    }
+
+    /**
+     * Convert committed events to an array.
+     * @returns {CommittedEvent[]} Array of committed events.
+     */
+    toArray(): CommittedEvent[] {
+        return [...this._events];
+    }
+
+    /**
+     * Gets the {@link AggregateRootVersion} of the aggregate root after all the events was applied.
+     *
+     * @returns {AggregateRootVersion}
+     */
+    get aggregateRootVersion(): AggregateRootVersion {
+        return this._events.length === 0 ? AggregateRootVersion.initial : this._events[this._events.length - 1].aggregateRootVersion;
+    }
+
+
+    private throwIfEventLogVersionIsOutOfOrder(event: CommittedAggregateEvent, previousEvent: CommittedAggregateEvent) {
+        if (event.eventLogSequenceNumber.value <= previousEvent.eventLogSequenceNumber.value) {
+            throw new EventLogSequenceNumberIsOutOfOrder(event.eventLogSequenceNumber, previousEvent.eventLogSequenceNumber);
+        }
+    }
+
+    private throwIfAggregateRootVersionIsOutOfOrder(event: CommittedAggregateEvent) {
+        if (event.aggregateRootVersion.value !== this._nextAggregateRootVersion.value) {
+            throw new AggregateRootVersionIsOutOfOrder(event.aggregateRootVersion, this._nextAggregateRootVersion);
+        }
+    }
+
+    private throwIfEventWasAppliedByOtherAggreateRoot(event: CommittedAggregateEvent) {
+        if (!event.aggregateRootId.equals(this.aggregateRootId)) {
+            throw new EventWasAppliedByOtherAggregateRoot(event.aggregateRootId, this.aggregateRootId);
+        }
+    }
+
+    private throwIfEventWasAppliedToOtherEventSource(event: CommittedAggregateEvent) {
+        if (!event.eventSourceId.equals(this.eventSourceId)) {
+            throw new EventWasAppliedToOtherEventSource(event.eventSourceId, this.eventSourceId);
+        }
+    }
+
+    private throwIfEventContentIsNullOrUndefined(event: CommittedAggregateEvent) {
+        if (!event.content) {
+            throw new EventContentNeedsToBeDefined();
+        }
+    }
+}
+

--- a/Source/events/CommittedAggregateEvents.ts
+++ b/Source/events/CommittedAggregateEvents.ts
@@ -45,6 +45,22 @@ export class CommittedAggregateEvents implements Iterable<CommittedAggregateEven
         }
     }
 
+    /**
+     * Gets whether or not there are events.
+     * @returns {Boolean}
+     */
+    get hasEvents(): boolean {
+        return this._events.length > 0;
+    }
+
+    /**
+     * Gets the length of the committed events array.
+     * @returns {Number}
+     */
+    get length(): number {
+        return this._events.length;
+    }
+
     /** @inheritdoc */
     [Symbol.iterator](): Iterator<CommittedAggregateEvent> {
         return this._events[Symbol.iterator]();

--- a/Source/events/CommittedAggregateEvents.ts
+++ b/Source/events/CommittedAggregateEvents.ts
@@ -38,6 +38,7 @@ export class CommittedAggregateEvents implements Iterable<CommittedAggregateEven
             this.throwIfEventWasAppliedToOtherEventSource(event);
             this.throwIfEventWasAppliedByOtherAggreateRoot(event);
             this.throwIfAggregateRootVersionIsOutOfOrder(event);
+            this._nextAggregateRootVersion = this._nextAggregateRootVersion.next();
         });
 
         if (events) {

--- a/Source/events/EventBuilderMethodAlreadyCalled.ts
+++ b/Source/events/EventBuilderMethodAlreadyCalled.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * The exception that is called when build methods that does not allow for multiple calls gets called multiple times.
+ */
+export class EventBuilderMethodAlreadyCalled extends Error {
+    constructor(method: string) {
+        super(`The method '${method}' can only be called once while building.`);
+    }
+}

--- a/Source/events/EventContentNeedsToBeDefined.ts
+++ b/Source/events/EventContentNeedsToBeDefined.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export class EventContentNeedsToBeDefined extends Error {
+
+    /**
+     * Initializes a new instance of {@link EventContentNeedsToBeDefined}
+     */
+    constructor() {
+        super('Event content can not be null or undefined');
+    }
+}

--- a/Source/events/EventConverters.ts
+++ b/Source/events/EventConverters.ts
@@ -4,14 +4,17 @@
 import { DateTime } from 'luxon';
 import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 import { CommittedEvent as PbCommittedEvent } from '@dolittle/runtime.contracts/Runtime/Events/Committed_pb';
-import { UncommittedEvent as PbUncommittedEvent } from '@dolittle/runtime.contracts/Runtime/Events/Uncommitted_pb';
+import {
+    UncommittedEvent as PbUncommittedEvent,
+    UncommittedAggregateEvents as PbUncommittedAggregateEvents
+} from '@dolittle/runtime.contracts/Runtime/Events/Uncommitted_pb';
 
 import { EventType } from '@dolittle/sdk.artifacts';
 import { eventTypes, guids, executionContexts } from '@dolittle/sdk.protobuf';
 
-import { CommittedEvent as SdkCommittedEvent } from './CommittedEvent';
-import { EventSourceId } from './EventSourceId';
-import { MissingExecutionContext } from './MissingExecutionContext';
+import { CommittedEvent as SdkCommittedEvent } from './CommittedEvent';
+import { EventSourceId } from './EventSourceId';
+import { MissingExecutionContext } from './MissingExecutionContext';
 import { EventLogSequenceNumber } from './EventLogSequenceNumber';
 
 /**
@@ -62,7 +65,6 @@ export class EventConverters {
         );
         return committedEvent;
     }
-
 
     /**
      * Convert a SDK committed event to protobuf representation

--- a/Source/events/EventConverters.ts
+++ b/Source/events/EventConverters.ts
@@ -78,10 +78,7 @@ export class EventConverters {
             executionContexts.toSDK(executionContext),
             eventTypes.toSDK(input.getType()),
             JSON.parse(input.getContent()),
-            input.getPublic(),
-            false,
-            EventLogSequenceNumber.from(input.getEventlogsequencenumber()),
-            DateTime.fromJSDate(new Date())
+            input.getPublic()
         );
         return committedEvent;
     }

--- a/Source/events/EventLogSequenceNumberIsOutOfOrder.ts
+++ b/Source/events/EventLogSequenceNumberIsOutOfOrder.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { EventLogSequenceNumber } from './EventLogSequenceNumber';
+
+/**
+ * The exception that gets thrown when a sequence of events are not valid for the Aggregate Root it is being used with.
+ */
+
+export class EventLogSequenceNumberIsOutOfOrder extends Error {
+
+    /**
+     * Initializes a new instance of {@link AggregateRootVersionIsOutOfOrder}.
+     * @param {EventLogSequenceNumber} version The attempted sequence number.
+     * @param {EventLogSequenceNumber} expectedSequenceNumber The expected sequence number.
+     */
+    constructor(sequenceNumber: EventLogSequenceNumber, expectedSequenceNumber: EventLogSequenceNumber) {
+        super(`Event Log Sequence is out of order because Event Log Sequence Number  '${sequenceNumber}' is not greater than '${expectedSequenceNumber}'.`);
+    }
+}

--- a/Source/events/EventSourceId.ts
+++ b/Source/events/EventSourceId.ts
@@ -15,6 +15,15 @@ export class EventSourceId extends ConceptAs<Guid, '@dolittle/sdk.events.EventSo
     constructor(id: Guid) {
         super(id, '@dolittle/sdk.events.EventSourceId');
     }
+
+    /**
+     * Create a new {@link EventSourceId} with a new unique identifier
+     * @returns {EventSourceId}
+     */
+    static new(): EventSourceId {
+        return new EventSourceId(Guid.create());
+    }
+
     /**
      * Creates an {EventSourceId} from a guid.
      *

--- a/Source/events/EventStore.ts
+++ b/Source/events/EventStore.ts
@@ -22,6 +22,7 @@ import {CommitEventsResult } from './CommitEventsResult';
 import { Guid } from '@dolittle/rudiments';
 import { AggregateRootId } from './AggregateRootId';
 import { CommitForAggregateBuilder } from './CommitForAggregateBuilder';
+import { CommittedAggregateEvents } from './CommittedAggregateEvents';
 
 /**
  * Represents an implementation of {@link IEventStore}
@@ -62,6 +63,11 @@ export class EventStore implements IEventStore {
     /** @inheritdoc */
     forAggregate(aggregateRootId: AggregateRootId): CommitForAggregateBuilder {
         return new CommitForAggregateBuilder(this, this._eventTypes, aggregateRootId, this._logger);
+    }
+
+    /** @inheritdoc */
+    fetchForAggregate(aggregateRootId: AggregateRootId, eventSourceId: EventSourceId): CommittedAggregateEvents {
+        return new CommittedAggregateEvents(eventSourceId, aggregateRootId, ...[]);
     }
 
 

--- a/Source/events/EventStore.ts
+++ b/Source/events/EventStore.ts
@@ -20,6 +20,8 @@ import { UncommittedEvent } from './UncommittedEvent';
 import { EventConverters } from './EventConverters';
 import {CommitEventsResult } from './CommitEventsResult';
 import { Guid } from '@dolittle/rudiments';
+import { AggregateRootId } from './AggregateRootId';
+import { CommitForAggregateBuilder } from './CommitForAggregateBuilder';
 
 /**
  * Represents an implementation of {@link IEventStore}
@@ -56,6 +58,12 @@ export class EventStore implements IEventStore {
         const events: UncommittedEvent[] = [this.toUncommittedEvent(event, eventSourceId, eventType, true)];
         return this.commitInternal(events, cancellation);
     }
+
+    /** @inheritdoc */
+    forAggregate(aggregateRootId: AggregateRootId): CommitForAggregateBuilder {
+        return new CommitForAggregateBuilder(this, this._eventTypes, aggregateRootId, this._logger);
+    }
+
 
     private async commitInternal(events: UncommittedEvent[], cancellation = Cancellation.default): Promise<CommitEventsResult> {
         const uncommittedEvents = events.map(event =>

--- a/Source/events/EventStoreBuilder.ts
+++ b/Source/events/EventStoreBuilder.ts
@@ -19,7 +19,7 @@ export class EventStoreBuilder {
         private _eventTypes: IEventTypes,
         private _executionContext: ExecutionContext,
         private _logger: Logger) {
-        }
+    }
 
     /**
      * Build an {@link IEventStore} for the given tenant.

--- a/Source/events/EventWasAppliedByOtherAggregateRoot.ts
+++ b/Source/events/EventWasAppliedByOtherAggregateRoot.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { AggregateRootId } from './AggregateRootId';
+
+/**
+ * The exception that gets thrown when a an event is applied to an event source other than the one expected.
+ */
+
+export class EventWasAppliedByOtherAggregateRoot extends Error {
+
+    /**
+     * Initializes a new instance of {@link EventWasAppliedToOtherEventSource}.
+     * @param {AggregateRootId} aggregateRoot The applied event source.
+     * @param {AggregateRootId} expectedAggregateRoot The expected event source.
+     */
+    constructor(aggregateRoot: AggregateRootId, expectedAggregateRoot: AggregateRootId) {
+        super(`Aggregate Root '${aggregateRoot}' does not match with expected '${expectedAggregateRoot}'.`);
+    }
+}

--- a/Source/events/EventWasAppliedToOtherEventSource.ts
+++ b/Source/events/EventWasAppliedToOtherEventSource.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { EventSourceId } from './EventSourceId';
+
+/**
+ * The exception that gets thrown when a an event is applied to an event source other than the one expected.
+ */
+
+export class EventWasAppliedToOtherEventSource extends Error {
+
+    /**
+     * Initializes a new instance of {@link EventWasAppliedToOtherEventSource}
+     * @param {EventSourceId} eventSource The applied event source.
+     * @param {EventSourceId} expectedEventSource The expected event source.
+     */
+    constructor(eventSource: EventSourceId, expectedEventSource: EventSourceId) {
+        super(`Event Source '${eventSource}' does not match with expected '${expectedEventSource}'.`);
+    }
+}

--- a/Source/events/IEventStore.ts
+++ b/Source/events/IEventStore.ts
@@ -8,6 +8,8 @@ import { Cancellation } from '@dolittle/sdk.resilience';
 import { CommitEventsResult } from './CommitEventsResult';
 import { EventSourceId } from './EventSourceId';
 import { UncommittedEvent } from './UncommittedEvent';
+import { AggregateRootId } from './AggregateRootId';
+import { CommitForAggregateBuilder } from './CommitForAggregateBuilder';
 ;
 
 /**
@@ -48,4 +50,14 @@ export interface IEventStore {
      * on the actual type of the event.
      */
     commitPublic(event: any, eventSourceId: EventSourceId | Guid | string, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
+
+    /**
+     * Commit for aggregate root.
+     * @param {AggregateRoot} aggregateRootId Aggregate root to commit for.
+     * @param {Cancellation} cancellation The cancellation signal
+     * @returns {CommitForAggregateBuilder}
+     */
+    forAggregate(aggregateRootId: AggregateRootId): CommitForAggregateBuilder;
 }
+
+

--- a/Source/events/IEventStore.ts
+++ b/Source/events/IEventStore.ts
@@ -92,9 +92,20 @@ export interface IEventStore {
      * Fetches the {@link CommittedAggregateEvents} for an aggregate root.
      * @param {AggregateRootId} aggregateRootId The aggregate root to fetch for.
      * @param {EventSourceId} eventSourceId The event source id to fetch for.
-     * @returns {CommittedAggregateEvents}
+     * @param {Cancellation} cancellation The cancellation signal.
+     * @returns {Promise<CommittedAggregateEvents>}
      */
-    fetchForAggregate(aggregateRootId: AggregateRootId, eventSourceId: EventSourceId): CommittedAggregateEvents;
+    fetchForAggregate(aggregateRootId: AggregateRootId, eventSourceId: EventSourceId, cancellation?: Cancellation): Promise<CommittedAggregateEvents>;
+
+
+    /**
+     * Fetches the {@link CommittedAggregateEvents} for an aggregate root - synchronously.
+     * @param {AggregateRootId} aggregateRootId The aggregate root to fetch for.
+     * @param {EventSourceId} eventSourceId The event source id to fetch for.
+     * @param {Cancellation} cancellation The cancellation signal.
+     * @returns {Promise<CommittedAggregateEvents>}
+     */
+    fetchForAggregateSync(aggregateRootId: AggregateRootId, eventSourceId: EventSourceId, cancellation?: Cancellation): CommittedAggregateEvents;
 }
 
 

--- a/Source/events/IEventStore.ts
+++ b/Source/events/IEventStore.ts
@@ -10,6 +10,7 @@ import { EventSourceId } from './EventSourceId';
 import { UncommittedEvent } from './UncommittedEvent';
 import { AggregateRootId } from './AggregateRootId';
 import { CommitForAggregateBuilder } from './CommitForAggregateBuilder';
+import { CommittedAggregateEvents } from './CommittedAggregateEvents';
 ;
 
 /**
@@ -58,6 +59,14 @@ export interface IEventStore {
      * @returns {CommitForAggregateBuilder}
      */
     forAggregate(aggregateRootId: AggregateRootId): CommitForAggregateBuilder;
+
+    /**
+     * Fetches the {@link CommittedAggregateEvents} for an aggregate root.
+     * @param {AggregateRootId} aggregateRootId The aggregate root to fetch for.
+     * @param {EventSourceId} eventSourceId The event source id to fetch for.
+     * @returns {CommittedAggregateEvents}
+     */
+    fetchForAggregate(aggregateRootId: AggregateRootId, eventSourceId: EventSourceId): CommittedAggregateEvents;
 }
 
 

--- a/Source/events/IEventStore.ts
+++ b/Source/events/IEventStore.ts
@@ -12,6 +12,8 @@ import { AggregateRootId } from './AggregateRootId';
 import { CommitForAggregateBuilder } from './CommitForAggregateBuilder';
 import { CommittedAggregateEvents } from './CommittedAggregateEvents';
 import { UncommittedAggregateEvents } from './UncommittedAggregateEvents';
+import { AggregateRootVersion } from './AggregateRootVersion';
+import { CommitAggregateEventsResult } from './CommitAggregateEventsResult';
 ;
 
 /**
@@ -54,12 +56,29 @@ export interface IEventStore {
     commitPublic(event: any, eventSourceId: EventSourceId | Guid | string, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
 
     /**
-     * Commit a collection of events for an aggregate
-     * @param {UncommittedAggregateEvents} uncommittedAggregateEvents The uncommitted aggregate events
+     * Commit a single event for an aggregate.
+     * @param {*} event The content of the event.
+     * @param {EventSourceId | Guid | string } eventSourceId The source of the event - a unique identifier that is associated with the event.
+     * @param {AggregateRootId} aggregateRootId The type of the aggregate root that applied the event to the Event Source
+     * @param {AggregateRootVersion} expectedAggregateRootVersion The {AggregateRootVersion} of the Aggregate Root that was used to apply the rules that resulted in the Events.
+     * The events can only be committed to the Event Store if the version of Aggregate Root has not changed.
+     * @param {EventType|Guid|string} [eventType] An artifact or an identifier representing the artifact.
      * @param {Cancellation} cancellation The cancellation signal.
-     * @returns {Promise<CommittedAggregateEvents>}
+     * @returns {Promise<CommitEventsResponse>}
+     * @summary If no event type identifier or event type is supplied, it will look for associated artifacts based
+     * on the actual type of the event.
      */
-    commitForAggregate(uncommittedAggregateEvents: UncommittedAggregateEvents, cancellation?: Cancellation): Promise<CommittedAggregateEvents>;
+    commitForAggregate(event: any, eventSourceId: EventSourceId | Guid | string, aggregateRootId: AggregateRootId, expectedAggregateRootVersion: AggregateRootVersion, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitAggregateEventsResult>;
+
+    /**
+     * Commit a collection of events.
+     * @param {UncommittedEvent} events Collection of aggregate events.
+     * @param {Cancellation} cancellation The cancellation signal.
+     * @returns Promise<CommitEventsResponse>
+     * @summary If no artifact identifier or artifact is supplied, it will look for associated artifacts based
+     * @summary on the actual type of the event.
+     */
+    commitForAggregate(events: UncommittedAggregateEvents, cancellation?: Cancellation): Promise<CommitAggregateEventsResult>;
 
     /**
      * Commit for aggregate root.

--- a/Source/events/IEventStore.ts
+++ b/Source/events/IEventStore.ts
@@ -11,6 +11,7 @@ import { UncommittedEvent } from './UncommittedEvent';
 import { AggregateRootId } from './AggregateRootId';
 import { CommitForAggregateBuilder } from './CommitForAggregateBuilder';
 import { CommittedAggregateEvents } from './CommittedAggregateEvents';
+import { UncommittedAggregateEvents } from './UncommittedAggregateEvents';
 ;
 
 /**
@@ -24,7 +25,7 @@ export interface IEventStore {
      * @param {EventSourceId | Guid | string} eventSourceId The source of the event - a unique identifier that is associated with the event.
      * @param {EventType | EventTypeId | Guid | string} eventType An event type or an identifier representing the event type.
      * @param {Cancellation} cancellation The cancellation signal.
-     * @returns Promise<CommitEventsResult>
+     * @returns {Promise<CommitEventsResult>}
      * @summary If no event type identifier or event type is supplied, it will look for associated event types based
      * on the actual type of the event.
      */
@@ -34,7 +35,7 @@ export interface IEventStore {
      * Commit a collection of events.
      * @param {UncommittedEvent|UncommittedEvent[]} eventOrEvents The event or events.
      * @param {Cancellation} cancellation The cancellation signal.
-     * @returns Promise<CommitEventsResult>
+     * @returns {Promise<CommitEventsResult>}
      * @summary If no event type identifier or event type is supplied, it will look for associated event types based
      * @summary on the actual type of the event.
      */
@@ -46,11 +47,19 @@ export interface IEventStore {
      * @param {EventSourceId | Guid | string} eventSourceId The source of the event - a unique identifier that is associated with the event.
      * @param {EventType | EventTypeId | Guid | string} eventType An event type or an identifier representing the event type.
      * @param {Cancellation} cancellation The cancellation signal.
-     * @returns Promise<CommitEventsResult>
+     * @returns {Promise<CommitEventsResult>}
      * @summary If no event type identifier or event type is supplied, it will look for associated event types based
      * on the actual type of the event.
      */
     commitPublic(event: any, eventSourceId: EventSourceId | Guid | string, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
+
+    /**
+     * Commit a collection of events for an aggregate
+     * @param {UncommittedAggregateEvents} uncommittedAggregateEvents The uncommitted aggregate events
+     * @param {Cancellation} cancellation The cancellation signal.
+     * @returns {Promise<CommittedAggregateEvents>}
+     */
+    commitForAggregate(uncommittedAggregateEvents: UncommittedAggregateEvents, cancellation?: Cancellation): Promise<CommittedAggregateEvents>;
 
     /**
      * Commit for aggregate root.

--- a/Source/events/UncommittedAggregateEvent.ts
+++ b/Source/events/UncommittedAggregateEvent.ts
@@ -24,3 +24,5 @@ export interface UncommittedAggregateEvent {
      */
     public?: boolean;
 }
+
+

--- a/Source/events/UncommittedAggregateEvent.ts
+++ b/Source/events/UncommittedAggregateEvent.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+import { EventType, EventTypeId } from '@dolittle/sdk.artifacts';
+
+/**
+ * Represents and uncommitted aggregate event
+ */
+
+export interface UncommittedAggregateEvent {
+    /**
+     * An event type or an identifier representing the event type.
+     * @summary If no event type identifier or event type is supplied, it will look for associated event types based
+     * on the actual type of the event.
+     */
+    eventType?: EventType | EventTypeId;
+
+    /**
+     * The content of the event.
+     */
+    content: any;
+
+    /**
+     * Indicates whether the event is public or not.
+     */
+    public?: boolean;
+}

--- a/Source/events/UncommittedAggregateEvents.ts
+++ b/Source/events/UncommittedAggregateEvents.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { AggregateRootId } from './AggregateRootId';
+import { AggregateRootVersion } from './AggregateRootVersion';
+import { EventSourceId } from './EventSourceId';
+import { UncommittedAggregateEvent } from './UncommittedAggregateEvent';
+import { EventContentNeedsToBeDefined } from './EventContentNeedsToBeDefined';
+
+/**
+ * Represents a sequence of {@link UncommittedAggregateEvent}s that have not been committed to the Event Store.
+ */
+export class UncommittedAggregateEvents implements Iterable<UncommittedAggregateEvent> {
+    private _events: UncommittedAggregateEvent[] = [];
+
+    /**
+     * Creates an instance of {@link UncommittedAggregateEvents}.
+     */
+    constructor(readonly eventSourceId: EventSourceId, readonly aggregateRootId: AggregateRootId, readonly expectedAggregateRootVersion: AggregateRootVersion) {
+    }
+
+    /**
+     * Gets whether or not there are events.
+     * @returns {Boolean}
+     */
+    get hasEvents(): boolean {
+        return this._events.length > 0;
+    }
+
+    /**
+     * Gets the length of the committed events array.
+     * @returns {Number}
+     */
+    get length(): number {
+        return this._events.length;
+    }
+
+    /** @inheritdoc */
+    [Symbol.iterator](): Iterator<UncommittedAggregateEvent> {
+        return this._events[Symbol.iterator]();
+    }
+
+    add(event: UncommittedAggregateEvent) {
+        this.throwIfEventContentIsNullOrUndefined(event);
+        this._events.push(event);
+    }
+
+    private throwIfEventContentIsNullOrUndefined(event: UncommittedAggregateEvent) {
+        if (!event.content) {
+            throw new EventContentNeedsToBeDefined();
+        }
+    }
+}

--- a/Source/events/UncommittedAggregateEvents.ts
+++ b/Source/events/UncommittedAggregateEvents.ts
@@ -6,6 +6,7 @@ import { AggregateRootVersion } from './AggregateRootVersion';
 import { EventSourceId } from './EventSourceId';
 import { UncommittedAggregateEvent } from './UncommittedAggregateEvent';
 import { EventContentNeedsToBeDefined } from './EventContentNeedsToBeDefined';
+import { Guid } from '@dolittle/rudiments';
 
 /**
  * Represents a sequence of {@link UncommittedAggregateEvent}s that have not been committed to the Event Store.
@@ -16,7 +17,14 @@ export class UncommittedAggregateEvents implements Iterable<UncommittedAggregate
     /**
      * Creates an instance of {@link UncommittedAggregateEvents}.
      */
-    constructor(readonly eventSourceId: EventSourceId, readonly aggregateRootId: AggregateRootId, readonly expectedAggregateRootVersion: AggregateRootVersion) {
+    constructor(
+        readonly eventSourceId: EventSourceId,
+        readonly aggregateRootId: AggregateRootId,
+        readonly expectedAggregateRootVersion: AggregateRootVersion,
+        ...events: UncommittedAggregateEvent[]) {
+        if (events) {
+            this._events = events;
+        }
     }
 
     /**
@@ -43,6 +51,19 @@ export class UncommittedAggregateEvents implements Iterable<UncommittedAggregate
     add(event: UncommittedAggregateEvent) {
         this.throwIfEventContentIsNullOrUndefined(event);
         this._events.push(event);
+    }
+
+
+    static from(eventSourceId: Guid | string, aggregateRootId: AggregateRootId, expectedAggregateRootVersion: AggregateRootVersion, ...events: UncommittedAggregateEvent[]): UncommittedAggregateEvents {
+        return new UncommittedAggregateEvents(EventSourceId.from(eventSourceId), aggregateRootId, expectedAggregateRootVersion, ...events);
+    }
+
+    /**
+     * Convert uncommitted aggregate events to an array.
+     * @returns {UncommittedAggregateEvent[]} Array of committed events.
+     */
+    toArray(): UncommittedAggregateEvent[] {
+        return [...this._events];
     }
 
     private throwIfEventContentIsNullOrUndefined(event: UncommittedAggregateEvent) {

--- a/Source/events/index.ts
+++ b/Source/events/index.ts
@@ -28,6 +28,7 @@ export { EventConverters } from './EventConverters';
 export { IEventStore } from './IEventStore';
 export { UncommittedEvent } from './UncommittedEvent';
 export { UncommittedAggregateEvent } from './UncommittedAggregateEvent';
+export { UncommittedAggregateEvents } from './UncommittedAggregateEvents';
 export { EventStoreBuilder } from './EventStoreBuilder';
 
 export {

--- a/Source/events/index.ts
+++ b/Source/events/index.ts
@@ -1,8 +1,18 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+
+export { AggregateRootId } from './AggregateRootId';
+export { AggregateRootVersion } from './AggregateRootVersion';
+export { AggregateRootVersionIsOutOfOrder } from './AggregateRootVersionIsOutOfOrder';
+export { CommittedAggregateEvent } from './CommittedAggregateEvent';
+export { CommittedAggregateEvents } from './CommittedAggregateEvents';
+export { EventWasAppliedByOtherAggregateRoot } from './EventWasAppliedByOtherAggregateRoot';
+export { EventWasAppliedToOtherEventSource } from './EventWasAppliedToOtherEventSource';
+export { EventContentNeedsToBeDefined } from './EventContentNeedsToBeDefined';
 export { MissingEventsFromRuntime } from './MissingEventsFromRuntime';
 export { MissingExecutionContext } from './MissingExecutionContext';
+export { EventLogSequenceNumberIsOutOfOrder } from './EventLogSequenceNumberIsOutOfOrder';
 export { EventLogSequenceNumberMustBeAPositiveInteger } from './EventLogSequenceNumberMustBeAPositiveInteger';
 export { EventLogSequenceNumber } from './EventLogSequenceNumber';
 export { EventSourceId } from './EventSourceId';
@@ -28,5 +38,5 @@ export {
     EventTypesBuilder,
     EventTypesBuilderCallback,
     EventTypesFromDecorators,
-    UnableToResolveEventType,UnknownEventType
+    UnableToResolveEventType, UnknownEventType
 } from '@dolittle/sdk.artifacts';

--- a/Source/events/index.ts
+++ b/Source/events/index.ts
@@ -27,6 +27,7 @@ export { CommitEventsResult } from './CommitEventsResult';
 export { EventConverters } from './EventConverters';
 export { IEventStore } from './IEventStore';
 export { UncommittedEvent } from './UncommittedEvent';
+export { UncommittedAggregateEvent } from './UncommittedAggregateEvent';
 export { EventStoreBuilder } from './EventStoreBuilder';
 
 export {

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -33,19 +33,21 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/rudiments": "5.0.1",
         "@dolittle/concepts": "5.0.1",
+        "@dolittle/rudiments": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.21",
         "@dolittle/sdk.artifacts": "14.1.0",
         "@dolittle/sdk.execution": "14.1.0",
         "@dolittle/sdk.protobuf": "14.1.0",
-        "@dolittle/sdk.services": "14.1.0",
         "@dolittle/sdk.resilience": "14.1.0",
+        "@dolittle/sdk.services": "14.1.0",
+        "deasync": "^0.1.21",
         "luxon": "1.24.1",
         "rxjs": "6.6.0",
         "winston": "3.3.2"
     },
     "devDependencies": {
+        "@types/deasync": "^0.1.1",
         "@types/luxon": "1.24.1"
     }
 }

--- a/Source/events/syncPromise.ts
+++ b/Source/events/syncPromise.ts
@@ -1,0 +1,52 @@
+/* eslint-disable header/header */
+
+// This is a TS adjusted version of this: https://github.com/Yukaii/synchronized-promise/blob/master/lib/index.js
+
+/* 10 seconds */
+const DEFAULT_TIMEOUTS = 10 * 1000;
+
+const STATE = {
+    INITIAL: 'INITIAL',
+    RESOLVED: 'RESOLVED',
+    REJECTED: 'REJECTED'
+};
+
+const DEFAULT_TICK = 100;
+
+/**
+ * @param {Function} func Promise-base function that want to be transformed
+ * @param {Object} options Additional options
+ * @param {number} options.timeouts Function call timeouts
+ * @param {number} options.tick deasync tick, default to 100
+ * @returns {Function}
+ */
+export function syncPromise(thisArg: any, func: Function, options: any = {}) {
+    return (...args: any[]) => {
+        let promiseError, promiseValue;
+        let promiseStatus = STATE.INITIAL;
+        const timeouts = options.timeouts || DEFAULT_TIMEOUTS;
+        const tick = options.tick || DEFAULT_TICK;
+
+        func.apply(thisArg, args).then((value: any) => {
+            promiseValue = value;
+            promiseStatus = STATE.RESOLVED;
+        }).catch((e: any) => {
+            promiseError = e;
+            promiseStatus = STATE.REJECTED;
+        });
+
+        const waitUntil = new Date(new Date().getTime() + timeouts);
+        while ((waitUntil > new Date()) && promiseStatus === STATE.INITIAL) {
+            require('deasync').sleep(tick);
+        }
+
+        if (promiseStatus === STATE.RESOLVED) {
+            return promiseValue;
+        } else if (promiseStatus === STATE.REJECTED) {
+            throw promiseError;
+        } else {
+            throw new Error(`${func.name} called timeout`);
+        }
+    };
+}
+

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -36,6 +36,7 @@
     "dependencies": {
         "@dolittle/rudiments": "5.0.1",
         "@dolittle/runtime.contracts": "5.1.21",
+        "@dolittle/sdk.aggregates": "14.1.0",
         "@dolittle/sdk.artifacts": "14.1.0",
         "@dolittle/sdk.common": "14.1.0",
         "@dolittle/sdk.eventhorizon": "14.1.0",

--- a/Source/sdk/tsconfig.json
+++ b/Source/sdk/tsconfig.json
@@ -8,6 +8,7 @@
     "include": ["**/*.ts"],
     "exclude": ["node_modules", "Distribution"],
     "references": [
+        { "path": "../aggregates" },
         { "path": "../artifacts" },
         { "path": "../common" },
         { "path": "../events" },

--- a/Source/tsconfig.json
+++ b/Source/tsconfig.json
@@ -3,6 +3,7 @@
     "include": [],
     "references": [
         { "path": "./artifacts" },
+        { "path": "./aggregates" },
         { "path": "./common" },
         { "path": "./eventHorizon" },
         { "path": "./events" },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "workspaces": [
     "Source/*",
+    "Samples/Aggregates",
     "Samples/Kitchen",
     "Samples/Container",
     "Samples/EventHorizon"


### PR DESCRIPTION
## Summary

Adds aggregates to the SDK in a barebones matter, agnostic to whether there is IoC or not.

### Added

- System for working with aggregates and aggregate roots
- AggregateOf<> method on Client for creating an aggregate root operation on a specific aggregate
- Small sample showcasing the aggregates system

### Changed
- docker-compose in samples run with latest runtime versions