### PR TITLE
C# --> JS fix when describing installation script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Dolittle is a decentralized, distributed, event-driven microservice platform built to harness the power of events.
 
-This is our C# SDK, install it with:
+This is our JS SDK, install it with:
 ```shell
 npm install @dolittle/sdk 
 ```


### PR DESCRIPTION
## Summary

Small Readme fix concerning misplaced 'C#' in the installation step.

### Added

- None

### Changed

- Text change: 'C#' --> 'JS' at line 20 of README.md

### Fixed

- None

### Removed

- None

### Security

- None

### Deprecated

- None
