### PR TITLE
Change all interfaces to abstract classes.

### DIFF
--- a/Source/aggregates/AggregateOf.ts
+++ b/Source/aggregates/AggregateOf.ts
@@ -1,29 +1,30 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { Guid } from '@dolittle/rudiments';
 import { AggregateRootVersionIsOutOfOrder, CommittedAggregateEvent, CommittedAggregateEvents, EventSourceId, EventTypeId, EventWasAppliedByOtherAggregateRoot, EventWasAppliedToOtherEventSource, IEventStore, IEventTypes } from '@dolittle/sdk.events';
-import { IAggregateOf } from './IAggregateOf';
-import { IAggregateRootOperations } from './IAggregateRootOperations';
-import { Logger } from 'winston';
 import { Constructor } from '@dolittle/types';
-import { AggregateRootOperations } from './AggregateRootOperations';
+import { Logger } from 'winston';
 import { AggregateRoot } from './AggregateRoot';
 import { AggregateRootDecoratedTypes } from './AggregateRootDecoratedTypes';
-import { OnDecoratedMethods } from './OnDecoratedMethods';
+import { AggregateRootOperations } from './AggregateRootOperations';
+import { IAggregateOf } from './IAggregateOf';
+import { IAggregateRootOperations } from './IAggregateRootOperations';
 import { OnDecoratedMethod } from './OnDecoratedMethod';
-import { Guid } from '@dolittle/rudiments';
+import { OnDecoratedMethods } from './OnDecoratedMethods';
 
 /**
  * Represents an implementation of {@link IAggregateOf<TAggregateRoot>}.
  * @template TAggregateRoot
  */
-export class AggregateOf<TAggregateRoot extends AggregateRoot> implements IAggregateOf<TAggregateRoot> {
+export class AggregateOf<TAggregateRoot extends AggregateRoot> extends IAggregateOf<TAggregateRoot> {
 
     constructor(
         private readonly _type: Constructor<TAggregateRoot>,
         private readonly _eventStore: IEventStore,
         private readonly _eventTypes: IEventTypes,
         private readonly _logger: Logger) {
+        super();
     }
 
     /** @inheritdoc */

--- a/Source/aggregates/AggregateRootOperations.ts
+++ b/Source/aggregates/AggregateRootOperations.ts
@@ -1,25 +1,26 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { IAggregateRootOperations } from './IAggregateRootOperations';
-import { AggregateRootAction } from './AggregateRootAction';
-import { AggregateRoot } from './AggregateRoot';
-import { AggregateRootVersion, AggregateRootId, CommittedAggregateEvents, IEventStore, UncommittedAggregateEvent, IEventTypes } from '@dolittle/sdk.events';
-import { Logger } from 'winston';
+import { AggregateRootId, AggregateRootVersion, CommittedAggregateEvents, IEventStore, IEventTypes, UncommittedAggregateEvent } from '@dolittle/sdk.events';
 import { Constructor } from '@dolittle/types';
+import { Logger } from 'winston';
+import { AggregateRoot } from './AggregateRoot';
+import { AggregateRootAction } from './AggregateRootAction';
+import { IAggregateRootOperations } from './IAggregateRootOperations';
 
 
 /**
  * Represents an implementation of {@link IAggregateRootOperations<TAggregate>}
  * @template TAggregateRoot
  */
-export class AggregateRootOperations<TAggregateRoot extends AggregateRoot> implements IAggregateRootOperations<TAggregateRoot> {
+export class AggregateRootOperations<TAggregateRoot extends AggregateRoot> extends IAggregateRootOperations<TAggregateRoot> {
     constructor(
         private readonly _aggregateRootType: Constructor<any>,
         private readonly _eventStore: IEventStore,
         private readonly _aggregateRoot: TAggregateRoot,
         private readonly _eventTypes: IEventTypes,
         private readonly _logger: Logger) {
+        super();
     }
 
     /** @inheritdoc */

--- a/Source/aggregates/IAggregateOf.ts
+++ b/Source/aggregates/IAggregateOf.ts
@@ -2,26 +2,26 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { EventSourceId } from '@dolittle/sdk.events';
-import { IAggregateRootOperations } from './IAggregateRootOperations';
 import { AggregateRoot } from './AggregateRoot';
+import { IAggregateRootOperations } from './IAggregateRootOperations';
 
 /**
  * Defines a way to work with an {@link AggregateRoot}
  * @template TAggregate
  */
 
-export interface IAggregateOf<TAggregate extends AggregateRoot> {
+export abstract class IAggregateOf<TAggregate extends AggregateRoot> {
 
     /**
      * Create a new {@link AggregateRoot} with a random {@link EventSourceId}
      * @returns {IAggregateRootOperations<TAggregate>}
      */
-    create(): IAggregateRootOperations<TAggregate>;
+    abstract create (): IAggregateRootOperations<TAggregate>;
 
     /**
      * Gets an {@link AggregateRoot} with a given {@link EventSourceId}
      * @param {EventSourceId} eventSourceId {@link EventSourceId} of the {@link AggregateRoot}
      * @returns {IAggregateRootOperations<TAggregate>}
      */
-    get(eventSourceId: EventSourceId): IAggregateRootOperations<TAggregate>;
+    abstract get (eventSourceId: EventSourceId): IAggregateRootOperations<TAggregate>;
 }

--- a/Source/aggregates/IAggregateRootOperations.ts
+++ b/Source/aggregates/IAggregateRootOperations.ts
@@ -1,20 +1,20 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { AggregateRootAction } from './AggregateRootAction';
 import { AggregateRoot } from './AggregateRoot';
+import { AggregateRootAction } from './AggregateRootAction';
 
 /**
  * Defines a system for working with operations that can be formed on an {@link AggregateRoot}.
  * @template TAggregate {@link AggregateRoot} type
  */
 
-export interface IAggregateRootOperations<TAggregate extends AggregateRoot> {
+export abstract class IAggregateRootOperations<TAggregate extends AggregateRoot> {
 
     /**
      * Perform an operation on an {@link AggregateRoot}
      * @param {AggregateRootAction<TAggregate> action Callback for working with the aggregate root.
      * @returns {Promise<void>}
      */
-    perform(action: AggregateRootAction<TAggregate>): Promise<void>;
+    abstract perform (action: AggregateRootAction<TAggregate>): Promise<void>;
 }

--- a/Source/artifacts/EventTypes.ts
+++ b/Source/artifacts/EventTypes.ts
@@ -3,25 +3,26 @@
 
 import { Guid } from '@dolittle/rudiments';
 import { Constructor } from '@dolittle/types';
-import { UnknownType } from './UnknownType';
-import { EventTypeMap } from './EventTypeMap';
-import { IEventTypes } from './IEventTypes';
-import { EventType } from './EventType';
-import { UnknownEventType } from './UnknownEventType';
-import { EventTypeId } from './EventTypeId';
-import { UnableToResolveEventType } from './UnableToResolveEventType';
 import { CannotHaveMultipleEventTypesAssociatedWithType } from './CannotHaveMultipleEventTypesAssociatedWithType';
 import { CannotHaveMultipleTypesAssociatedWithEventType } from './CannotHaveMultipleTypesAssociatedWithEventType';
+import { EventType } from './EventType';
+import { EventTypeId } from './EventTypeId';
+import { EventTypeMap } from './EventTypeMap';
+import { IEventTypes } from './IEventTypes';
+import { UnableToResolveEventType } from './UnableToResolveEventType';
+import { UnknownEventType } from './UnknownEventType';
+import { UnknownType } from './UnknownType';
 
 /**
  * Represents an implementation of {@link IEventTypes}
  */
-export class EventTypes implements IEventTypes {
+export class EventTypes extends IEventTypes {
     /**
      * Initializes a new instance of {@link EventTypes}
      * @param {EventTypeMap<Constructor<any>>} [associations] Known associations
      */
     constructor(private _associations: EventTypeMap<Constructor<any>> = new EventTypeMap()) {
+        super();
     }
     /** @inheritdoc */
     hasTypeFor(input: EventType): boolean {

--- a/Source/artifacts/IEventTypes.ts
+++ b/Source/artifacts/IEventTypes.ts
@@ -3,41 +3,41 @@
 
 import { Guid } from '@dolittle/rudiments';
 import { Constructor } from '@dolittle/types';
-import { EventType } from './EventType';
+import { EventType } from './EventType';
 import { EventTypeId } from './EventTypeId';
 
 /**
  * Defines the system for working with {@link EventType}
  */
-export interface IEventTypes {
+export abstract class IEventTypes {
 
     /**
      * Check if there is a type associated with an artifact.
      * @param {EventType} input Artifact.
      * @returns {boolean} true if there is, false if not.
      */
-    hasTypeFor(input: EventType): boolean;
+    abstract hasTypeFor (input: EventType): boolean;
 
     /**
      * Get type for a given artifact.
      * @param {EventType} input Artifact.
      * @returns type for artifact.
      */
-    getTypeFor(input: EventType): Constructor<any>;
+    abstract getTypeFor (input: EventType): Constructor<any>;
 
     /**
      * Check if there is an {Artifact} definition for a given type.
      * @param {Function} type Type to check for.
      * @returns true if there is, false if not.
      */
-    hasFor(type: Constructor<any>): boolean;
+    abstract hasFor (type: Constructor<any>): boolean;
 
     /**
      * Get {Artifact} definition for a given type.
      * @param {Function} type Type to get for.
      * @returns {EventType} The artifact associated.
      */
-    getFor(type: Constructor<any>): EventType;
+    abstract getFor (type: Constructor<any>): EventType;
 
     /**
      * Resolves an artifact from optional input or the given object.
@@ -46,12 +46,12 @@ export interface IEventTypes {
      * @returns {EventType} Resolved event type.
      * @throws {UnableToResolveArtifact} If not able to resolve artifact.
      */
-    resolveFrom(object: any, input?: EventType | EventTypeId | Guid | string): EventType;
+    abstract resolveFrom (object: any, input?: EventType | EventTypeId | Guid | string): EventType;
 
     /**
      * Associate a type with a unique artifact identifier and optional generation.
      * @param {Constructor<any>} type Type to associate.
      * @param {EventType} eventType Artifact to associate with.
      */
-    associate(type: Constructor<any>, eventType: EventType): void;
+    abstract associate (type: Constructor<any>, eventType: EventType): void;
 }

--- a/Source/common/Container.ts
+++ b/Source/common/Container.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Constructor } from '@dolittle/types';
-import { IContainer } from './IContainer';
 import { DefaultContainerDoesNotSupportConstructorArguments } from './DefaultContainerDoesNotSupportConstructorArguments';
+import { IContainer } from './IContainer';
 
 /**
  * Represents an implementation of {@link IContainer}.
  */
-export class Container implements IContainer {
+export class Container extends IContainer {
 
     /** @inheritdoc */
     get(service: Constructor) {

--- a/Source/common/IContainer.ts
+++ b/Source/common/IContainer.ts
@@ -6,13 +6,12 @@ import { Constructor } from '@dolittle/types';
 /**
  * Defines an IoC Container for dependency inversion.
  */
-export interface IContainer {
+export abstract class IContainer {
 
     /**
      * Get the instance of a service.
      * @param {Function} service Type of service by its constructor to get
      * @returns The instance.
      */
-    get(service: Constructor): any;
+    abstract get (service: Constructor): any;
 }
-

--- a/Source/eventHorizon/EventHorizons.ts
+++ b/Source/eventHorizon/EventHorizons.ts
@@ -2,24 +2,24 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Guid } from '@dolittle/rudiments';
-import { Logger } from 'winston';
-import * as grpc from '@grpc/grpc-js';
-import { ExecutionContext } from '@dolittle/sdk.execution';
-import { callContexts, failures, guids } from '@dolittle/sdk.protobuf';
 import { SubscriptionsClient } from '@dolittle/runtime.contracts/EventHorizon/Subscriptions_grpc_pb';
 import { Subscription as PbSubscription, SubscriptionResponse as PbSubscriptionResponse } from '@dolittle/runtime.contracts/EventHorizon/Subscriptions_pb';
+import { ExecutionContext } from '@dolittle/sdk.execution';
+import { callContexts, failures, guids } from '@dolittle/sdk.protobuf';
+import * as grpc from '@grpc/grpc-js';
+import { Logger } from 'winston';
+import { IEventHorizons } from './IEventHorizons';
+import { Subscription } from './Subscription';
+import { SubscriptionCallbacks } from './SubscriptionCallbacks';
+import { SubscriptionDoesNotExist } from './SubscriptionDoesNotExist';
+import { SubscriptionResponse } from './SubscriptionResponse';
+import { TenantWithSubscriptions } from './TenantWithSubscriptions';
 
-import { Subscription } from './Subscription';
-import { IEventHorizons } from './IEventHorizons';
-import { SubscriptionResponse } from './SubscriptionResponse';
-import { TenantWithSubscriptions } from './TenantWithSubscriptions';
-import { SubscriptionCallbacks } from './SubscriptionCallbacks';
-import { SubscriptionDoesNotExist } from './SubscriptionDoesNotExist';
 
 /**
  * Represents an implementation of {@link IEventHorizons}.
  */
-export class EventHorizons implements IEventHorizons {
+export class EventHorizons extends IEventHorizons {
     private _subscriptionResponses: Map<Subscription, SubscriptionResponse> = new Map();
 
     /**
@@ -36,6 +36,7 @@ export class EventHorizons implements IEventHorizons {
         readonly subscriptions: TenantWithSubscriptions[],
         readonly callbacks: SubscriptionCallbacks,
         private _logger: Logger) {
+        super();
         this.subscribeAll();
     }
 

--- a/Source/eventHorizon/IEventHorizons.ts
+++ b/Source/eventHorizon/IEventHorizons.ts
@@ -1,23 +1,23 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Subscription } from './Subscription';
-import { TenantWithSubscriptions } from './TenantWithSubscriptions';
+import { Subscription } from './Subscription';
 import { SubscriptionResponse } from './SubscriptionResponse';
+import { TenantWithSubscriptions } from './TenantWithSubscriptions';
 
 /**
  * Defines the capabilities of the event horizons.
  */
-export interface IEventHorizons {
+export abstract class IEventHorizons {
     /**
      * Subscriptions by tenant.
      */
-    readonly subscriptions: TenantWithSubscriptions[];
+    abstract readonly subscriptions: TenantWithSubscriptions[];
 
     /**
      * Gets response for a specific {@link Subscription}.
      * @param {Subscription} subscription Subscription to get response for.
      * @throws {SubscriptionDoesNotExist} If subscription does not exist.
      */
-    getResponseFor(subscription: Subscription): SubscriptionResponse;
+    abstract getResponseFor (subscription: Subscription): SubscriptionResponse;
 }

--- a/Source/events.filtering/Filters.ts
+++ b/Source/events.filtering/Filters.ts
@@ -1,24 +1,24 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Logger } from 'winston';
-import { delay } from 'rxjs/operators';
-
 import { Cancellation, retryPipe } from '@dolittle/sdk.resilience';
-
-import { IFilters } from './IFilters';
-import { IFilterProcessor } from './IFilterProcessor';
+import { delay } from 'rxjs/operators';
+import { Logger } from 'winston';
+import { IFilterProcessor } from './IFilterProcessor';
+import { IFilters } from './IFilters';
 
 /**
  * Represents an implementation of {@link IFilters}.
  */
-export class Filters implements IFilters {
+export class Filters extends IFilters {
 
     /**
      * Initializes a new instance of {@link Filters}.
      * @param {Logger} _logger Logger for logging.
      */
-    constructor(private readonly _logger: Logger) {}
+    constructor(private readonly _logger: Logger) {
+        super();
+    }
 
     /** @inheritdoc */
     register(filterProcessor: IFilterProcessor, cancellation = Cancellation.default): void {

--- a/Source/events.filtering/IFilters.ts
+++ b/Source/events.filtering/IFilters.ts
@@ -7,12 +7,12 @@ import { IFilterProcessor } from './IFilterProcessor';
 /**
  * Defines the API for working with filters.
  */
-export interface IFilters {
+export abstract class IFilters {
 
     /**
      * Register a {@link IFilterProcessor} for processing events for filtering.
      * @param {IFilterProcessor} filterProcessor The filter processor.
      * @param {Cancellation} [cancellation] Optional cancellation.
      */
-    register(filterProcessor: IFilterProcessor, cancellation?: Cancellation): void;
+    abstract register (filterProcessor: IFilterProcessor, cancellation?: Cancellation): void;
 }

--- a/Source/events.handling/Builder/EventHandlerBuilder.ts
+++ b/Source/events.handling/Builder/EventHandlerBuilder.ts
@@ -1,27 +1,27 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Logger } from 'winston';
-
 import { Guid } from '@dolittle/rudiments';
-import { EventTypeMap, IEventTypes, ScopeId } from '@dolittle/sdk.events';
 import { EventHandlersClient } from '@dolittle/runtime.contracts/Events.Processing/EventHandlers_grpc_pb';
-import { Cancellation } from '@dolittle/sdk.resilience';
+import { IContainer } from '@dolittle/sdk.common';
+import { EventTypeMap, IEventTypes, ScopeId } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
-
-import { EventHandler, EventHandlerId, EventHandlerSignature, IEventHandlers } from '..';
+import { Cancellation } from '@dolittle/sdk.resilience';
+import { Logger } from 'winston';
+import { EventHandler, EventHandlerId, EventHandlerSignature, IEventHandlers } from '..';
 import { EventHandlerProcessor } from '../Internal';
-
 import { EventHandlerMethodsBuilder } from './EventHandlerMethodsBuilder';
 import { ICanBuildAndRegisterAnEventHandler } from './ICanBuildAndRegisterAnEventHandler';
-import { IContainer } from '@dolittle/sdk.common';
+
+
+
 
 export type EventHandlerBuilderCallback = (builder: EventHandlerBuilder) => void;
 
 /**
  * Represents a builder for building {@link IEventHandler} - event handlers.
  */
-export class EventHandlerBuilder implements ICanBuildAndRegisterAnEventHandler {
+export class EventHandlerBuilder extends ICanBuildAndRegisterAnEventHandler {
     private _methodsBuilder?: EventHandlerMethodsBuilder;
     private _scopeId: ScopeId = ScopeId.default;
     private _partitioned!: boolean;
@@ -31,6 +31,7 @@ export class EventHandlerBuilder implements ICanBuildAndRegisterAnEventHandler {
      * @param {EventHandlerId} _eventHandlerId The unique identifier of the event handler to build for.
      */
     constructor(private _eventHandlerId: EventHandlerId) {
+        super();
     }
 
     /**

--- a/Source/events.handling/Builder/EventHandlerClassBuilder.ts
+++ b/Source/events.handling/Builder/EventHandlerClassBuilder.ts
@@ -1,35 +1,32 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Logger } from 'winston';
-
 import { Guid } from '@dolittle/rudiments';
-import { Constructor } from '@dolittle/types';
-
+import { EventHandlersClient } from '@dolittle/runtime.contracts/Events.Processing/EventHandlers_grpc_pb';
 import { IContainer } from '@dolittle/sdk.common';
 import { EventType, EventTypeId, EventTypeMap, Generation, IEventTypes } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { Cancellation } from '@dolittle/sdk.resilience';
-
-import { EventHandlersClient } from '@dolittle/runtime.contracts/Events.Processing/EventHandlers_grpc_pb';
-
+import { Constructor } from '@dolittle/types';
+import { Logger } from 'winston';
 import { EventHandler, EventHandlerSignature, IEventHandlers } from '..';
 import { EventHandlerProcessor } from '../Internal';
-
+import { CannotRegisterEventHandlerThatIsNotAClass } from './CannotRegisterEventHandlerThatIsNotAClass';
+import { CouldNotCreateInstanceOfEventHandler } from './CouldNotCreateInstanceOfEventHandler';
 import { EventHandlerDecoratedTypes } from './EventHandlerDecoratedTypes';
 import { eventHandler as eventHandlerDecorator } from './eventHandlerDecorator';
-import { handles as handlesDecorator } from './handlesDecorator';
-import { HandlesDecoratedMethods } from './HandlesDecoratedMethods';
 import { HandlesDecoratedMethod } from './HandlesDecoratedMethod';
+import { HandlesDecoratedMethods } from './HandlesDecoratedMethods';
+import { handles as handlesDecorator } from './handlesDecorator';
 import { ICanBuildAndRegisterAnEventHandler } from './ICanBuildAndRegisterAnEventHandler';
-import { CouldNotCreateInstanceOfEventHandler } from './CouldNotCreateInstanceOfEventHandler';
-import { CannotRegisterEventHandlerThatIsNotAClass } from './CannotRegisterEventHandlerThatIsNotAClass';
 
-export class EventHandlerClassBuilder<T> implements ICanBuildAndRegisterAnEventHandler {
+
+export class EventHandlerClassBuilder<T> extends ICanBuildAndRegisterAnEventHandler {
     private readonly _eventHandlerType: Constructor<T>;
     private readonly _getInstance: (container: IContainer) => T;
 
     constructor(typeOrInstance: Constructor<T> | T) {
+        super();
         if (typeOrInstance instanceof Function) {
             this._eventHandlerType = typeOrInstance;
             this._getInstance = container => container.get(typeOrInstance);

--- a/Source/events.handling/Builder/ICanBuildAndRegisterAnEventHandler.ts
+++ b/Source/events.handling/Builder/ICanBuildAndRegisterAnEventHandler.ts
@@ -1,18 +1,15 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Logger } from 'winston';
-
 import { EventHandlersClient } from '@dolittle/runtime.contracts/Events.Processing/EventHandlers_grpc_pb';
-
-import { IEventTypes } from '@dolittle/sdk.events';
 import { IContainer } from '@dolittle/sdk.common';
+import { IEventTypes } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { Cancellation } from '@dolittle/sdk.resilience';
-
+import { Logger } from 'winston';
 import { IEventHandlers } from '..';
 
-export interface ICanBuildAndRegisterAnEventHandler {
+export abstract class ICanBuildAndRegisterAnEventHandler {
 
     /**
      * Builds and registers an event handler
@@ -25,12 +22,12 @@ export interface ICanBuildAndRegisterAnEventHandler {
      * @param {Logger} logger The logger
      * @param {Cancellation} cancellation The cancellation token.
      */
-    buildAndRegister(
+    abstract buildAndRegister (
         client: EventHandlersClient,
         eventHandlers: IEventHandlers,
         container: IContainer,
         executionContext: ExecutionContext,
         eventTypes: IEventTypes,
         logger: Logger,
-        cancellation: Cancellation): void
+        cancellation: Cancellation): void;
 }

--- a/Source/events.handling/EventHandler.ts
+++ b/Source/events.handling/EventHandler.ts
@@ -2,16 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { EventContext, EventType, EventTypeMap, ScopeId } from '@dolittle/sdk.events';
-
-import { IEventHandler } from './IEventHandler';
-import { EventHandlerSignature } from './EventHandlerSignature';
-import { MissingEventHandlerForType } from './MissingEventHandlerForType';
-import { EventHandlerId } from './EventHandlerId';
+import { EventHandlerId } from './EventHandlerId';
+import { EventHandlerSignature } from './EventHandlerSignature';
+import { IEventHandler } from './IEventHandler';
+import { MissingEventHandlerForType } from './MissingEventHandlerForType';
 
 /**
  * Represents an implementation of {@link IEventHandler}.
  */
-export class EventHandler implements IEventHandler {
+export class EventHandler extends IEventHandler {
 
     /**
      * Initializes a new instance of {@link EventHandler}
@@ -25,6 +24,7 @@ export class EventHandler implements IEventHandler {
         readonly scopeId: ScopeId,
         readonly partitioned: boolean,
         readonly handleMethodsByEventType: EventTypeMap<EventHandlerSignature<any>>) {
+        super();
     }
 
     /** @inheritdoc */

--- a/Source/events.handling/EventHandlers.ts
+++ b/Source/events.handling/EventHandlers.ts
@@ -1,23 +1,23 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { Cancellation, retryPipe } from '@dolittle/sdk.resilience';
 import { delay } from 'rxjs/operators';
 import { Logger } from 'winston';
-import { Cancellation, retryPipe } from '@dolittle/sdk.resilience';
-
 import { IEventHandlers } from './IEventHandlers';
 import { EventHandlerProcessor } from './Internal';
 
 /**
  * Represents an implementation of {IEventHandlers}.
  */
-export class EventHandlers implements IEventHandlers {
+export class EventHandlers extends IEventHandlers {
 
     /**
      * Initializes an instance of {@link EventHandlers}.
      * @param {Logger} _logger For logging.
      */
     constructor(private readonly _logger: Logger) {
+        super();
     }
 
     /** @inheritdoc */

--- a/Source/events.handling/IEventHandler.ts
+++ b/Source/events.handling/IEventHandler.ts
@@ -2,32 +2,32 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { EventContext, EventType, ScopeId } from '@dolittle/sdk.events';
-
 import { EventHandlerId } from './EventHandlerId';
+
 
 /**
  * Defines an event handler
  */
-export interface IEventHandler {
+export abstract class IEventHandler {
     /**
      * Gets the unique identifier for event handler - {@link EventHandlerId}
      */
-    readonly eventHandlerId: EventHandlerId;
+    abstract readonly eventHandlerId: EventHandlerId;
 
     /**
      * Gets the scope the event handler is in
      */
-    readonly scopeId: ScopeId;
+    abstract readonly scopeId: ScopeId;
 
     /**
      * Gets whether or not the event handler is partitioned.
      */
-    readonly partitioned: boolean;
+    abstract readonly partitioned: boolean;
 
     /**
      * Gets the event types identified by its artifact that is handled by this event handler.
      */
-    readonly handledEvents: Iterable<EventType>;
+    abstract readonly handledEvents: Iterable<EventType>;
 
     /**
      * Handle an event.
@@ -35,5 +35,5 @@ export interface IEventHandler {
      * @param {EventType} eventType The event type.
      * @param {EventContext} context The context in which the event is in.
      */
-    handle(event: any, eventType: EventType, context: EventContext): Promise<void>;
+    abstract handle (event: any, eventType: EventType, context: EventContext): Promise<void>;
 }

--- a/Source/events.handling/IEventHandlers.ts
+++ b/Source/events.handling/IEventHandlers.ts
@@ -2,18 +2,18 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Cancellation } from '@dolittle/sdk.resilience';
-
 import { EventHandlerProcessor } from './Internal';
+
 
 /**
  * Defines the system for event handlers
  */
-export interface IEventHandlers {
+export abstract class IEventHandlers {
 
     /**
      * Register an event handler
      * @param {EventHandlerProcessor} eventHandlerProcessor Event handler processor to register.
      * @param {Cancellation} cancellation Used to close the connection to the Runtime.
      */
-    register(eventHandlerProcessor: EventHandlerProcessor, cancellation?: Cancellation): void;
+    abstract register (eventHandlerProcessor: EventHandlerProcessor, cancellation?: Cancellation): void;
 }

--- a/Source/events.processing/Internal/EventProcessor.ts
+++ b/Source/events.processing/Internal/EventProcessor.ts
@@ -1,36 +1,33 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Observable } from 'rxjs';
-import { repeat } from 'rxjs/operators';
-import { Logger } from 'winston';
-
-import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
-
 import { ConceptAs } from '@dolittle/concepts';
+import { Failure as PbFailure } from '@dolittle/contracts/Protobuf/Failure_pb';
 import { Guid } from '@dolittle/rudiments';
-import { IReverseCallClient } from '@dolittle/sdk.services';
+import { ProcessorFailure, RetryProcessingState } from '@dolittle/runtime.contracts/Events.Processing/Processors_pb';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { failures } from '@dolittle/sdk.protobuf';
 import { Cancellation, RetryPolicy, retryWithPolicy } from '@dolittle/sdk.resilience';
-
-import { Failure as PbFailure } from '@dolittle/contracts/Protobuf/Failure_pb';
-import { RetryProcessingState, ProcessorFailure } from '@dolittle/runtime.contracts/Events.Processing/Processors_pb';
-
+import { IReverseCallClient } from '@dolittle/sdk.services';
+import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
+import { Observable } from 'rxjs';
+import { repeat } from 'rxjs/operators';
+import { Logger } from 'winston';
 import { RegistrationFailed } from '..';
-
 import { IEventProcessor } from './IEventProcessor';
 
 /**
  * Partial implementation of {@link IEventProcessor}.
  */
-export abstract class EventProcessor<TIdentifier extends ConceptAs<Guid, string>, TRegisterArguments, TRegisterResponse, TRequest, TResponse> implements IEventProcessor {
+export abstract class EventProcessor<TIdentifier extends ConceptAs<Guid, string>, TRegisterArguments, TRegisterResponse, TRequest, TResponse> extends IEventProcessor {
     private _pingTimeout = 1;
 
     constructor(
         private _kind: string,
         protected _identifier: TIdentifier,
-        protected _logger: Logger) {}
+        protected _logger: Logger) {
+        super();
+    }
 
     /** @inheritdoc */
     register(cancellation: Cancellation): Observable<never> {

--- a/Source/events.processing/Internal/IEventProcessor.ts
+++ b/Source/events.processing/Internal/IEventProcessor.ts
@@ -1,23 +1,21 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Observable } from 'rxjs';
-
 import { Cancellation, RetryPolicy } from '@dolittle/sdk.resilience';
+import { Observable } from 'rxjs';
 
 /**
  * Defines a system that handles the behavior of event processors that registers with the Runtime and handles processing requests.
  */
-export interface IEventProcessor {
+export abstract class IEventProcessor {
     /**
      * Registers the event processor with the Runtime, and if successful starts handling requests.
      * @param {Cancellation} cancellation Used to cancel the registration and processing.
      * @returns {Observable} Representing the connection to the Runtime.
      */
-    register(cancellation: Cancellation): Observable<never>;
+    abstract register (cancellation: Cancellation): Observable<never>;
 
-    registerWithPolicy(policy: RetryPolicy, cancellation: Cancellation): Observable<never>;
+    abstract registerWithPolicy (policy: RetryPolicy, cancellation: Cancellation): Observable<never>;
 
-    registerForeverWithPolicy(policy: RetryPolicy, cancellation: Cancellation): Observable<never>;
+    abstract registerForeverWithPolicy (policy: RetryPolicy, cancellation: Cancellation): Observable<never>;
 }
-

--- a/Source/events/CommittedAggregateEvents.ts
+++ b/Source/events/CommittedAggregateEvents.ts
@@ -6,9 +6,9 @@ import { AggregateRootVersion } from './AggregateRootVersion';
 import { AggregateRootVersionIsOutOfOrder } from './AggregateRootVersionIsOutOfOrder';
 import { CommittedAggregateEvent } from './CommittedAggregateEvent';
 import { CommittedEvent } from './CommittedEvent';
-import { EventSourceId } from './EventSourceId';
 import { EventContentNeedsToBeDefined } from './EventContentNeedsToBeDefined';
 import { EventLogSequenceNumberIsOutOfOrder } from './EventLogSequenceNumberIsOutOfOrder';
+import { EventSourceId } from './EventSourceId';
 import { EventWasAppliedByOtherAggregateRoot } from './EventWasAppliedByOtherAggregateRoot';
 import { EventWasAppliedToOtherEventSource } from './EventWasAppliedToOtherEventSource';
 
@@ -26,7 +26,6 @@ export class CommittedAggregateEvents implements Iterable<CommittedAggregateEven
      * @param {...CommittedEvent[]} events Events to initialize with.
      */
     constructor(readonly eventSourceId: EventSourceId, readonly aggregateRootId: AggregateRootId, ...events: CommittedAggregateEvent[]) {
-
         events.forEach((event, eventIndex) => {
             if (eventIndex === 0) {
                 this._nextAggregateRootVersion = event.aggregateRootVersion;
@@ -115,4 +114,3 @@ export class CommittedAggregateEvents implements Iterable<CommittedAggregateEven
         }
     }
 }
-

--- a/Source/events/EventStore.ts
+++ b/Source/events/EventStore.ts
@@ -1,48 +1,43 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Logger } from 'winston';
-import { map } from 'rxjs/operators';
-
-import { callContexts, failures, guids } from '@dolittle/sdk.protobuf';
-import { EventType, EventTypeId, IEventTypes } from '@dolittle/sdk.artifacts';
-import { ExecutionContext } from '@dolittle/sdk.execution';
-import { Cancellation } from '@dolittle/sdk.resilience';
-import { reactiveUnary } from '@dolittle/sdk.services';
-
+import { Failure } from '@dolittle/contracts/Protobuf/Failure_pb';
+import { Guid } from '@dolittle/rudiments';
+import { Aggregate } from '@dolittle/runtime.contracts/Events/Aggregate_pb';
+import { CommittedAggregateEvents as PbCommittedAggregatedEvents } from '@dolittle/runtime.contracts/Events/Committed_pb';
 import { EventStoreClient } from '@dolittle/runtime.contracts/Events/EventStore_grpc_pb';
 import {
-    CommitEventsRequest,
-    CommitEventsResponse as PbCommitEventsResponse,
     CommitAggregateEventsRequest,
+    CommitEventsRequest,
     FetchForAggregateRequest
 } from '@dolittle/runtime.contracts/Events/EventStore_pb';
 import { UncommittedAggregateEvents as PbUncommittedAggregateEvents } from '@dolittle/runtime.contracts/Events/Uncommitted_pb';
-import { CommittedAggregateEvents as PbCommittedAggregatedEvents } from '@dolittle/runtime.contracts/Events/Committed_pb';
-
-import { CommittedEvents } from './CommittedEvents';
-import { IEventStore } from './IEventStore';
-import { EventSourceId } from './EventSourceId';
-import { UncommittedEvent } from './UncommittedEvent';
-import { EventConverters } from './EventConverters';
-import { CommitEventsResult } from './CommitEventsResult';
-import { Guid } from '@dolittle/rudiments';
+import { EventType, EventTypeId, IEventTypes } from '@dolittle/sdk.artifacts';
+import { ExecutionContext } from '@dolittle/sdk.execution';
+import { callContexts, failures, guids } from '@dolittle/sdk.protobuf';
+import { Cancellation } from '@dolittle/sdk.resilience';
+import { reactiveUnary } from '@dolittle/sdk.services';
+import { map } from 'rxjs/operators';
+import { Logger } from 'winston';
 import { AggregateRootId } from './AggregateRootId';
-import { CommitForAggregateBuilder } from './CommitForAggregateBuilder';
-import { CommittedAggregateEvents } from './CommittedAggregateEvents';
-import { UncommittedAggregateEvents } from './UncommittedAggregateEvents';
 import { AggregateRootVersion } from './AggregateRootVersion';
 import { CommitAggregateEventsResult } from './CommitAggregateEventsResult';
+import { CommitEventsResult } from './CommitEventsResult';
+import { CommitForAggregateBuilder } from './CommitForAggregateBuilder';
 import { CommittedAggregateEvent } from './CommittedAggregateEvent';
-import { Aggregate } from '@dolittle/runtime.contracts/Events/Aggregate_pb';
-
+import { CommittedAggregateEvents } from './CommittedAggregateEvents';
+import { CommittedEvents } from './CommittedEvents';
+import { EventConverters } from './EventConverters';
+import { EventSourceId } from './EventSourceId';
+import { IEventStore } from './IEventStore';
 import { syncPromise } from './syncPromise';
-import { Failure } from '@dolittle/contracts/Protobuf/Failure_pb';
+import { UncommittedAggregateEvents } from './UncommittedAggregateEvents';
+import { UncommittedEvent } from './UncommittedEvent';
 
 /**
  * Represents an implementation of {@link IEventStore}
  */
-export class EventStore implements IEventStore {
+export class EventStore extends IEventStore {
 
     private _fetchForAggregateSync: Function;
 
@@ -58,7 +53,7 @@ export class EventStore implements IEventStore {
         private _eventTypes: IEventTypes,
         private _executionContext: ExecutionContext,
         private _logger: Logger) {
-
+        super();
         this._fetchForAggregateSync = syncPromise(this, this.fetchForAggregate);
     }
 

--- a/Source/events/IEventStore.ts
+++ b/Source/events/IEventStore.ts
@@ -4,22 +4,20 @@
 import { Guid } from '@dolittle/rudiments';
 import { EventType, EventTypeId } from '@dolittle/sdk.artifacts';
 import { Cancellation } from '@dolittle/sdk.resilience';
-
-import { CommitEventsResult } from './CommitEventsResult';
-import { EventSourceId } from './EventSourceId';
-import { UncommittedEvent } from './UncommittedEvent';
 import { AggregateRootId } from './AggregateRootId';
-import { CommitForAggregateBuilder } from './CommitForAggregateBuilder';
-import { CommittedAggregateEvents } from './CommittedAggregateEvents';
-import { UncommittedAggregateEvents } from './UncommittedAggregateEvents';
 import { AggregateRootVersion } from './AggregateRootVersion';
 import { CommitAggregateEventsResult } from './CommitAggregateEventsResult';
-;
+import { CommitEventsResult } from './CommitEventsResult';
+import { CommitForAggregateBuilder } from './CommitForAggregateBuilder';
+import { CommittedAggregateEvents } from './CommittedAggregateEvents';
+import { EventSourceId } from './EventSourceId';
+import { UncommittedAggregateEvents } from './UncommittedAggregateEvents';
+import { UncommittedEvent } from './UncommittedEvent';
 
 /**
  * Defines the API surface for the event store
  */
-export interface IEventStore {
+export abstract class IEventStore {
 
     /**
      * Commit a single event.
@@ -31,7 +29,7 @@ export interface IEventStore {
      * @summary If no event type identifier or event type is supplied, it will look for associated event types based
      * on the actual type of the event.
      */
-    commit(event: any, eventSourceId: EventSourceId | Guid | string, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
+    abstract commit (event: any, eventSourceId: EventSourceId | Guid | string, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
 
     /**
      * Commit a collection of events.
@@ -41,7 +39,7 @@ export interface IEventStore {
      * @summary If no event type identifier or event type is supplied, it will look for associated event types based
      * @summary on the actual type of the event.
      */
-    commit(eventOrEvents: UncommittedEvent | UncommittedEvent[], cancellation?: Cancellation): Promise<CommitEventsResult>;
+    abstract commit (eventOrEvents: UncommittedEvent | UncommittedEvent[], cancellation?: Cancellation): Promise<CommitEventsResult>;
 
     /**
      * Commit a single public event.
@@ -53,7 +51,7 @@ export interface IEventStore {
      * @summary If no event type identifier or event type is supplied, it will look for associated event types based
      * on the actual type of the event.
      */
-    commitPublic(event: any, eventSourceId: EventSourceId | Guid | string, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
+    abstract commitPublic (event: any, eventSourceId: EventSourceId | Guid | string, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
 
     /**
      * Commit a single event for an aggregate.
@@ -68,7 +66,7 @@ export interface IEventStore {
      * @summary If no event type identifier or event type is supplied, it will look for associated artifacts based
      * on the actual type of the event.
      */
-    commitForAggregate(event: any, eventSourceId: EventSourceId | Guid | string, aggregateRootId: AggregateRootId, expectedAggregateRootVersion: AggregateRootVersion, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitAggregateEventsResult>;
+    abstract commitForAggregate (event: any, eventSourceId: EventSourceId | Guid | string, aggregateRootId: AggregateRootId, expectedAggregateRootVersion: AggregateRootVersion, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitAggregateEventsResult>;
 
     /**
      * Commit a collection of events.
@@ -78,7 +76,7 @@ export interface IEventStore {
      * @summary If no artifact identifier or artifact is supplied, it will look for associated artifacts based
      * @summary on the actual type of the event.
      */
-    commitForAggregate(events: UncommittedAggregateEvents, cancellation?: Cancellation): Promise<CommitAggregateEventsResult>;
+    abstract commitForAggregate (events: UncommittedAggregateEvents, cancellation?: Cancellation): Promise<CommitAggregateEventsResult>;
 
     /**
      * Commit for aggregate root.
@@ -86,7 +84,7 @@ export interface IEventStore {
      * @param {Cancellation} cancellation The cancellation signal
      * @returns {CommitForAggregateBuilder}
      */
-    forAggregate(aggregateRootId: AggregateRootId): CommitForAggregateBuilder;
+    abstract forAggregate (aggregateRootId: AggregateRootId): CommitForAggregateBuilder;
 
     /**
      * Fetches the {@link CommittedAggregateEvents} for an aggregate root.
@@ -95,7 +93,7 @@ export interface IEventStore {
      * @param {Cancellation} cancellation The cancellation signal.
      * @returns {Promise<CommittedAggregateEvents>}
      */
-    fetchForAggregate(aggregateRootId: AggregateRootId, eventSourceId: EventSourceId, cancellation?: Cancellation): Promise<CommittedAggregateEvents>;
+    abstract fetchForAggregate (aggregateRootId: AggregateRootId, eventSourceId: EventSourceId, cancellation?: Cancellation): Promise<CommittedAggregateEvents>;
 
 
     /**
@@ -105,7 +103,5 @@ export interface IEventStore {
      * @param {Cancellation} cancellation The cancellation signal.
      * @returns {Promise<CommittedAggregateEvents>}
      */
-    fetchForAggregateSync(aggregateRootId: AggregateRootId, eventSourceId: EventSourceId, cancellation?: Cancellation): CommittedAggregateEvents;
+    abstract fetchForAggregateSync (aggregateRootId: AggregateRootId, eventSourceId: EventSourceId, cancellation?: Cancellation): CommittedAggregateEvents;
 }
-
-

--- a/Source/events/UncommittedAggregateEvent.ts
+++ b/Source/events/UncommittedAggregateEvent.ts
@@ -6,7 +6,7 @@ import { EventType, EventTypeId } from '@dolittle/sdk.artifacts';
  * Represents and uncommitted aggregate event
  */
 
-export interface UncommittedAggregateEvent {
+export abstract class UncommittedAggregateEvent {
     /**
      * An event type or an identifier representing the event type.
      * @summary If no event type identifier or event type is supplied, it will look for associated event types based
@@ -24,5 +24,3 @@ export interface UncommittedAggregateEvent {
      */
     public?: boolean;
 }
-
-

--- a/Source/events/UncommittedEvent.ts
+++ b/Source/events/UncommittedEvent.ts
@@ -7,26 +7,26 @@ import { EventSourceId } from './EventSourceId';
 /**
  * Represents and uncommitted event
  */
-export interface UncommittedEvent {
+export abstract class UncommittedEvent {
     /**
      * The source of the event - a unique identifier that is associated with the event.
      */
-    eventSourceId: EventSourceId;
+    abstract eventSourceId: EventSourceId;
 
     /**
      * An event type or an identifier representing the event type.
      * @summary If no event type identifier or event type is supplied, it will look for associated event types based
      * on the actual type of the event.
      */
-    eventType?: EventType | EventTypeId;
+    abstract eventType?: EventType | EventTypeId;
 
     /**
      * The content of the event.
      */
-    content: any;
+    abstract content: any;
 
     /**
      * Indicates whether the event is public or not.
      */
-    public?: boolean;
+    abstract public?: boolean;
 }

--- a/Source/projections/Builder/ICanBuildAndRegisterAProjection.ts
+++ b/Source/projections/Builder/ICanBuildAndRegisterAProjection.ts
@@ -1,17 +1,15 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Logger } from 'winston';
-
-import { IEventTypes } from '@dolittle/sdk.events';
+import { ProjectionsClient } from '@dolittle/runtime.contracts/Events.Processing/Projections_grpc_pb';
 import { IContainer } from '@dolittle/sdk.common';
+import { IEventTypes } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { Cancellation } from '@dolittle/sdk.resilience';
-import { ProjectionsClient } from '@dolittle/runtime.contracts/Events.Processing/Projections_grpc_pb';
-
+import { Logger } from 'winston';
 import { IProjections } from '..';
 
-export interface ICanBuildAndRegisterAProjection {
+export abstract class ICanBuildAndRegisterAProjection {
 
     /**
      * Builds and registers a projection
@@ -23,12 +21,12 @@ export interface ICanBuildAndRegisterAProjection {
      * @param {Logger} logger The logger.
      * @param {Cancellation} cancellation The cancellation token.
      */
-    buildAndRegister(
+    abstract buildAndRegister (
         client: ProjectionsClient,
         projections: IProjections,
         container: IContainer,
         executionContext: ExecutionContext,
         eventTypes: IEventTypes,
         logger: Logger,
-        cancellation: Cancellation): void
+        cancellation: Cancellation): void;
 }

--- a/Source/projections/Builder/ProjectionBuilder.ts
+++ b/Source/projections/Builder/ProjectionBuilder.ts
@@ -1,25 +1,20 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Logger } from 'winston';
-
 import { Guid } from '@dolittle/rudiments';
+import { ProjectionsClient } from '@dolittle/runtime.contracts/Events.Processing/Projections_grpc_pb';
 import { IContainer } from '@dolittle/sdk.common';
 import { IEventTypes, ScopeId } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { Cancellation } from '@dolittle/sdk.resilience';
 import { Constructor } from '@dolittle/types';
-
-import { ProjectionsClient } from '@dolittle/runtime.contracts/Events.Processing/Projections_grpc_pb';
-
-import { IProjections, projection, ProjectionId } from '..';
-
+import { Logger } from 'winston';
+import { IProjectionAssociations, IProjections, ProjectionId } from '..';
 import { ICanBuildAndRegisterAProjection } from './ICanBuildAndRegisterAProjection';
 import { ProjectionBuilderForReadModel } from './ProjectionBuilderForReadModel';
 import { ReadModelAlreadyDefinedForProjection } from './ReadModelAlreadyDefinedForProjection';
-import { IProjectionAssociations } from '../Store';
 
-export class ProjectionBuilder implements ICanBuildAndRegisterAProjection {
+export class ProjectionBuilder extends ICanBuildAndRegisterAProjection {
     private _scopeId: ScopeId = ScopeId.default;
     private _readModelTypeOrInstance?: Constructor<any> | any;
     private _builder?: ProjectionBuilderForReadModel<any>;
@@ -28,7 +23,9 @@ export class ProjectionBuilder implements ICanBuildAndRegisterAProjection {
      * Initializes a new instance of {@link ProjectionBuilder}.
      * @param {ProjectionId} _projectionId  The unique identifier of the projection to build for
      */
-    constructor(private readonly _projectionId: ProjectionId, private readonly _projectionAssociations: IProjectionAssociations) { }
+    constructor(private readonly _projectionId: ProjectionId, private readonly _projectionAssociations: IProjectionAssociations) {
+        super();
+    }
 
     /**
      * Defines the projection to operate on a specific {@link ScopeId}.

--- a/Source/projections/Builder/ProjectionBuilderForReadModel.ts
+++ b/Source/projections/Builder/ProjectionBuilderForReadModel.ts
@@ -1,23 +1,23 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Logger } from 'winston';
-
 import { Guid } from '@dolittle/rudiments';
+import { ProjectionsClient } from '@dolittle/runtime.contracts/Events.Processing/Projections_grpc_pb';
 import { IContainer } from '@dolittle/sdk.common';
 import { EventType, EventTypeId, EventTypeMap, Generation, IEventTypes, ScopeId } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { Cancellation } from '@dolittle/sdk.resilience';
 import { Constructor } from '@dolittle/types';
-
-import { ProjectionsClient } from '@dolittle/runtime.contracts/Events.Processing/Projections_grpc_pb';
-
+import { Logger } from 'winston';
 import { IProjections, KeySelector, Projection, ProjectionCallback, ProjectionId } from '..';
 import { ProjectionProcessor } from '../Internal';
-
 import { ICanBuildAndRegisterAProjection } from './ICanBuildAndRegisterAProjection';
 import { KeySelectorBuilder } from './KeySelectorBuilder';
 import { KeySelectorBuilderCallback } from './KeySelectorBuilderCallback';
+
+
+
+
 
 type TypeOrEventType = Constructor<any> | EventType;
 type OnMethodSpecification = [TypeOrEventType, KeySelectorBuilderCallback, ProjectionCallback<any>];
@@ -25,7 +25,7 @@ type OnMethodSpecification = [TypeOrEventType, KeySelectorBuilderCallback, Proje
 /**
  * Represents a builder for building {@link IProjection}.
  */
-export class ProjectionBuilderForReadModel<T> implements ICanBuildAndRegisterAProjection {
+export class ProjectionBuilderForReadModel<T> extends ICanBuildAndRegisterAProjection {
     private _onMethods: OnMethodSpecification[] = [];
 
     /**
@@ -35,7 +35,9 @@ export class ProjectionBuilderForReadModel<T> implements ICanBuildAndRegisterAPr
     constructor(
         private _projectionId: ProjectionId,
         private _readModelTypeOrInstance: Constructor<T> | T,
-        private _scopeId: ScopeId) { }
+        private _scopeId: ScopeId) {
+        super();
+    }
 
     /**
      * Defines the projection to operate in a specific {@link ScopeId}.

--- a/Source/projections/Builder/ProjectionClassBuilder.ts
+++ b/Source/projections/Builder/ProjectionClassBuilder.ts
@@ -1,32 +1,30 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Logger } from 'winston';
-
-import { EventType, EventTypeId, EventTypeMap, Generation, IEventTypes } from '@dolittle/sdk.events';
-import { Cancellation } from '@dolittle/sdk.resilience';
 import { Guid } from '@dolittle/rudiments';
-import { IContainer } from '@dolittle/sdk.common';
-import { ExecutionContext } from '@dolittle/sdk.execution';
-import { Constructor } from '@dolittle/types';
-
 import { ProjectionsClient } from '@dolittle/runtime.contracts/Events.Processing/Projections_grpc_pb';
-
-import { IProjections, ProjectionCallback, Projection, KeySelector, DeleteReadModelInstance } from '..';
+import { IContainer } from '@dolittle/sdk.common';
+import { EventType, EventTypeId, EventTypeMap, Generation, IEventTypes } from '@dolittle/sdk.events';
+import { ExecutionContext } from '@dolittle/sdk.execution';
+import { Cancellation } from '@dolittle/sdk.resilience';
+import { Constructor } from '@dolittle/types';
+import { Logger } from 'winston';
+import { DeleteReadModelInstance, IProjections, KeySelector, Projection, ProjectionCallback } from '..';
 import { ProjectionProcessor } from '../Internal';
-
 import { CannotRegisterProjectionThatIsNotAClass } from './CannotRegisterProjectionThatIsNotAClass';
 import { ICanBuildAndRegisterAProjection } from './ICanBuildAndRegisterAProjection';
-import { on as onDecorator } from './onDecorator';
 import { OnDecoratedMethod } from './OnDecoratedMethod';
 import { OnDecoratedMethods } from './OnDecoratedMethods';
-import { projection as projectionDecorator } from './projectionDecorator';
+import { on as onDecorator } from './onDecorator';
 import { ProjectionDecoratedTypes } from './ProjectionDecoratedTypes';
+import { projection as projectionDecorator } from './projectionDecorator';
 
-export class ProjectionClassBuilder<T> implements ICanBuildAndRegisterAProjection {
+
+export class ProjectionClassBuilder<T> extends ICanBuildAndRegisterAProjection {
     private readonly _projectionType: Constructor<T>;
 
     constructor(typeOrInstance: Constructor<T> | T) {
+        super();
         if (typeOrInstance instanceof Function) {
             this._projectionType = typeOrInstance;
 

--- a/Source/projections/IProjection.ts
+++ b/Source/projections/IProjection.ts
@@ -3,40 +3,40 @@
 
 import { EventType, ScopeId } from '@dolittle/sdk.events';
 import { Constructor } from '@dolittle/types';
-
 import { DeleteReadModelInstance } from './DeleteReadModelInstance';
 import { EventSelector } from './EventSelector';
 import { ProjectionContext } from './ProjectionContext';
 import { ProjectionId } from './ProjectionId';
 
+
 /**
  * Defines a projection.
  */
-export interface IProjection<T> {
+export abstract class IProjection<T> {
     /**
      * Gets the {@link ProjectionId} for the projection.
      */
-    readonly projectionId: ProjectionId;
+    abstract readonly projectionId: ProjectionId;
 
     /**
      * Gets the read model type the projection is for.
      */
-    readonly readModelTypeOrInstance: Constructor<T> | T;
+    abstract readonly readModelTypeOrInstance: Constructor<T> | T;
 
     /**
      * Gets the initial state of the projection.
      */
-    readonly initialState?: T;
+    abstract readonly initialState?: T;
 
     /**
      * Gets the scope the projection is in.
      */
-    readonly scopeId: ScopeId;
+    abstract readonly scopeId: ScopeId;
 
     /**
      * Gets the events used by the projection.
      */
-    readonly events: Iterable<EventSelector>;
+    abstract readonly events: Iterable<EventSelector>;
 
     /**
      * Handle an event and update a readmodel.
@@ -45,5 +45,5 @@ export interface IProjection<T> {
      * @param {EventType} eventType The event type.
      * @param {ProjectionContext} context The context for the projection processing.
      */
-    on(readModel: T, event: any, eventType: EventType, context: ProjectionContext): Promise<T | DeleteReadModelInstance> | T | DeleteReadModelInstance;
+    abstract on (readModel: T, event: any, eventType: EventType, context: ProjectionContext): Promise<T | DeleteReadModelInstance> | T | DeleteReadModelInstance;
 }

--- a/Source/projections/IProjections.ts
+++ b/Source/projections/IProjections.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Cancellation } from '@dolittle/sdk.resilience';
-
 import { ProjectionProcessor } from './Internal';
+
 
 /**
  * Defines the system for projections
  */
-export interface IProjections {
+export abstract class IProjections {
 
     /**
      * Register a a projection
@@ -16,5 +16,5 @@ export interface IProjections {
      * @param {ProjectionProcessor} projectionProcessor Projection processor to register.
      * @param {Cancellation} cancellation Used to close the connection to the Runtime.
      */
-    register<T>(projectionProcessor: ProjectionProcessor<T>, cancellation?: Cancellation): void;
+    abstract register<T> (projectionProcessor: ProjectionProcessor<T>, cancellation?: Cancellation): void;
 }

--- a/Source/projections/Projection.ts
+++ b/Source/projections/Projection.ts
@@ -3,7 +3,6 @@
 
 import { EventType, EventTypeMap, ScopeId } from '@dolittle/sdk.events';
 import { Constructor } from '@dolittle/types';
-
 import { DeleteReadModelInstance } from './DeleteReadModelInstance';
 import { EventSelector } from './EventSelector';
 import { IProjection } from './IProjection';
@@ -13,7 +12,9 @@ import { ProjectionCallback } from './ProjectionCallback';
 import { ProjectionContext } from './ProjectionContext';
 import { ProjectionId } from './ProjectionId';
 
-export class Projection<T> implements IProjection<T> {
+
+export class Projection<T> extends IProjection<T> {
+    initialState?: T | undefined;
 
     /** @inheritdoc */
     readonly events: Iterable<EventSelector>;
@@ -30,6 +31,7 @@ export class Projection<T> implements IProjection<T> {
         readonly readModelTypeOrInstance: Constructor<T> | T,
         readonly scopeId: ScopeId,
         private readonly _eventMap: EventTypeMap<[ProjectionCallback<any>, KeySelector]>) {
+        super();
         const eventSelectors: EventSelector[] = [];
         for (const [eventType, [, keySelector]] of this._eventMap.entries()) {
             eventSelectors.push(new EventSelector(eventType, keySelector));

--- a/Source/projections/Projections.ts
+++ b/Source/projections/Projections.ts
@@ -1,25 +1,23 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { Cancellation, retryPipe } from '@dolittle/sdk.resilience';
 import { delay } from 'rxjs/operators';
 import { Logger } from 'winston';
-
-import { Cancellation, retryPipe } from '@dolittle/sdk.resilience';
-
 import { ProjectionProcessor } from './Internal';
-
 import { IProjections } from './IProjections';
 
 /**
  * Represents an implementation of {IProjections}
  */
-export class Projections implements IProjections {
+export class Projections extends IProjections {
 
     /**
      * Initializes an instance of {@link Projections}.
      * @param {Logger} _logger For logging.
      */
     constructor(private readonly _logger: Logger) {
+        super();
     }
 
     /** @inheritdoc */

--- a/Source/projections/Store/Converters/IConvertProjectionsToSDK.ts
+++ b/Source/projections/Store/Converters/IConvertProjectionsToSDK.ts
@@ -1,29 +1,26 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Constructor } from '@dolittle/types';
-
 import { ProjectionCurrentState } from '@dolittle/runtime.contracts/Projections/State_pb';
-
-import { Key } from '../..';
+import { Constructor } from '@dolittle/types';
 import { CurrentState } from '..';
+import { Key } from '../..';
 
 /**
  * Defines a system that converts projections to SDK representations.
  */
-export interface IConvertProjectionsToSDK
-{
+export abstract class IConvertProjectionsToSDK {
     /**
      * Convert from the runtime respresentation to the SDK's representation of the current state of a projection.
      * @param {Constructor<TProjection> | undefined} type The optional read model type to convert to.
      * @param {ProjectionCurrentState} source The current state to convert.
      */
-    convert<TProjection = any>(type: Constructor<TProjection> | undefined, source: ProjectionCurrentState): CurrentState<TProjection>;
+    abstract convert<TProjection = any> (type: Constructor<TProjection> | undefined, source: ProjectionCurrentState): CurrentState<TProjection>;
 
     /**
      * Convert from an list of runtime respresentations of the current state of a projection to the SDK's representation.
      * @param {Constructor<TProjection> | undefined} type The optional read model type to convert to.
      * @param {ProjectionCurrentState[]} sources A list of states to convert.
      */
-    convertAll<TProjection = any>(type: Constructor<TProjection> | undefined, sources: ProjectionCurrentState[]): Map<Key, CurrentState<TProjection>>;
+    abstract convertAll<TProjection = any> (type: Constructor<TProjection> | undefined, sources: ProjectionCurrentState[]): Map<Key, CurrentState<TProjection>>;
 }

--- a/Source/projections/Store/Converters/ProjectionsToSDKConverter.ts
+++ b/Source/projections/Store/Converters/ProjectionsToSDKConverter.ts
@@ -1,18 +1,15 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Constructor } from '@dolittle/types';
-
 import { ProjectionCurrentState, ProjectionCurrentStateType } from '@dolittle/runtime.contracts/Projections/State_pb';
-
+import { Constructor } from '@dolittle/types';
 import { CurrentState } from '..';
-
+import { Key } from '../..';
 import { CurrentStateType } from '../CurrentStateType';
 import { IConvertProjectionsToSDK } from './IConvertProjectionsToSDK';
 import { UnknownCurrentStateType } from './UnknownCurrentStateType';
-import { Key } from '../..';
 
-export class ProjectionsToSDKConverter implements IConvertProjectionsToSDK {
+export class ProjectionsToSDKConverter extends IConvertProjectionsToSDK {
 
     /** @inheritdoc */
     convert<TProjection = any>(type: Constructor<TProjection> | undefined, state: ProjectionCurrentState): CurrentState<TProjection> {

--- a/Source/projections/Store/IProjectionAssociations.ts
+++ b/Source/projections/Store/IProjectionAssociations.ts
@@ -6,14 +6,14 @@ import { Constructor } from '@dolittle/types';
 import { ProjectionId } from '..';
 import { ProjectionAssociation } from './ProjectionAssociation';
 
-export interface IProjectionAssociations {
+export abstract class IProjectionAssociations {
 
     /**
      * Associate a projection
      * @template T
      * @param {Constructor<T> | T} typeOrInstance The type or instance of the type of the projection.
      */
-    associate<T>(typeOrInstance: Constructor<T> | T): void;
+    abstract associate<T> (typeOrInstance: Constructor<T> | T): void;
     /**
      * Associate a projection.
      * @template T
@@ -21,7 +21,7 @@ export interface IProjectionAssociations {
      * @param {ProjectionId} projection The projections id.
      * @param {ScopeId} scope The scope id of the projection.
      */
-    associate<T>(typeOrInstance: Constructor<T> | T, projection: ProjectionId, scope: ScopeId): void;
+    abstract associate<T> (typeOrInstance: Constructor<T> | T, projection: ProjectionId, scope: ScopeId): void;
     /**
      * Associate a projection.
      * @template T
@@ -29,18 +29,18 @@ export interface IProjectionAssociations {
      * @param {ProjectionId} projection The projections id.
      * @param {ScopeId} scope The scope id of the projection.
      */
-    associate<T>(typeOrInstance: Constructor<T> | T, projection?: ProjectionId, scope?: ScopeId): void;
+    abstract associate<T> (typeOrInstance: Constructor<T> | T, projection?: ProjectionId, scope?: ScopeId): void;
 
     /**
      * Get the projection associated with a type.
      * @template T
      * @param {Constructor<T>} type The type of the projection.
      */
-    getFor<T>(type: Constructor<T>): ProjectionAssociation;
+    abstract getFor<T> (type: Constructor<T>): ProjectionAssociation;
     /**
      * Get the type the projection is associated with.
      * @param {ProjectionId} projection The id of the projection.
      * @param {ScopeId} scope The scope of the projection.
      */
-    getType(projection: ProjectionId, scope: ScopeId): Constructor<any>;
+    abstract getType (projection: ProjectionId, scope: ScopeId): Constructor<any>;
 }

--- a/Source/projections/Store/IProjectionStore.ts
+++ b/Source/projections/Store/IProjectionStore.ts
@@ -5,15 +5,14 @@ import { Guid } from '@dolittle/rudiments';
 import { ScopeId } from '@dolittle/sdk.events';
 import { Cancellation } from '@dolittle/sdk.resilience';
 import { Constructor } from '@dolittle/types';
-
 import { Key, ProjectionId } from '..';
-
 import { CurrentState } from './CurrentState';
+
 
 /**
  * Defines the API surface for getting projections.
  */
-export interface IProjectionStore {
+export abstract class IProjectionStore {
     /**
      * Gets a projection state by key for a projection associated with a type.
      * @template TProjection
@@ -22,7 +21,7 @@ export interface IProjectionStore {
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<CurrentState<TProjection>>}
      */
-    get<TProjection>(type: Constructor<TProjection>, key: Key | any, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
+    abstract get<TProjection> (type: Constructor<TProjection>, key: Key | any, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
 
     /**
      * Gets a projection state by key for a projection specified by projection identifier.
@@ -33,7 +32,7 @@ export interface IProjectionStore {
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<CurrentState<TProjection>>}
      */
-    get<TProjection>(type: Constructor<TProjection>, key: Key | any, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
+    abstract get<TProjection> (type: Constructor<TProjection>, key: Key | any, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
 
     /**
      * Gets a projection state by key for a projection specified by projection and scope identifier.
@@ -45,7 +44,7 @@ export interface IProjectionStore {
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<CurrentState<TProjection>>}
      */
-    get<TProjection>(type: Constructor<TProjection>, key: Key | any, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
+    abstract get<TProjection> (type: Constructor<TProjection>, key: Key | any, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
 
     /**
      * Gets a projection state by key for a projection specified by projection identifier.
@@ -54,7 +53,7 @@ export interface IProjectionStore {
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<CurrentState<any>>}
      */
-    get(key: Key | any, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<any>>;
+    abstract get (key: Key | any, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<any>>;
 
     /**
      * Gets a projection state by key for a projection specified by projection and scope identifier.
@@ -64,7 +63,7 @@ export interface IProjectionStore {
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<CurrentState<any>>}
      */
-    get(key: Key | any, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<any>>;
+    abstract get (key: Key | any, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<any>>;
 
     /**
      * Gets all projection states for a projection associated with a type.
@@ -73,7 +72,7 @@ export interface IProjectionStore {
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<CurrentState<TPRojection>>}
      */
-    getAll<TProjection>(type: Constructor<TProjection>, cancellation?: Cancellation): Promise<Map<Key, CurrentState<TProjection>>>;
+    abstract getAll<TProjection> (type: Constructor<TProjection>, cancellation?: Cancellation): Promise<Map<Key, CurrentState<TProjection>>>;
 
     /**
      * Gets all projection states for a projection specified by projection identifier.
@@ -83,7 +82,7 @@ export interface IProjectionStore {
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<CurrentState<TPRojection>>}
      */
-    getAll<TProjection>(type: Constructor<TProjection>, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<Map<Key, CurrentState<TProjection>>>;
+    abstract getAll<TProjection> (type: Constructor<TProjection>, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<Map<Key, CurrentState<TProjection>>>;
 
     /**
      * Gets all projection states for a projection specified by projection and scope identifier.
@@ -94,7 +93,7 @@ export interface IProjectionStore {
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<Map<Key, CurrentState<TProjection>>}
      */
-    getAll<TProjection>(type: Constructor<TProjection>, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<Map<Key, CurrentState<TProjection>>>;
+    abstract getAll<TProjection> (type: Constructor<TProjection>, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<Map<Key, CurrentState<TProjection>>>;
 
     /**
      * Gets all projection states for a projection specified by projection identifier.
@@ -102,7 +101,7 @@ export interface IProjectionStore {
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<Map<Key, CurrentState<any>>}
      */
-    getAll(projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<Map<Key,CurrentState<any>>>;
+    abstract getAll (projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<Map<Key,CurrentState<any>>>;
 
     /**
      * Gets all projection states for a projection specified by projection and scope identifier.
@@ -111,5 +110,5 @@ export interface IProjectionStore {
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<Map<Key, CurrentState<any>>}
      */
-    getAll(projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<Map<Key, CurrentState<any>>>;
+    abstract getAll (projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<Map<Key, CurrentState<any>>>;
 }

--- a/Source/projections/Store/ProjectionAssociations.ts
+++ b/Source/projections/Store/ProjectionAssociations.ts
@@ -10,7 +10,7 @@ import { NoTypeAssociatedWithProjection } from './NoTypeAssociatedWithProjection
 import { ProjectionAssociation } from './ProjectionAssociation';
 import { TypeIsNotAProjection } from './TypeIsNotAProjection';
 
-export class ProjectionAssociations implements IProjectionAssociations {
+export class ProjectionAssociations extends IProjectionAssociations {
     readonly _associationsToType: Map<ProjectionAssociation, Constructor<any>> = new Map();
     readonly _typeToAssociations: Map<Constructor<any>, ProjectionAssociation> = new Map();
 

--- a/Source/projections/Store/ProjectionStore.ts
+++ b/Source/projections/Store/ProjectionStore.ts
@@ -1,32 +1,28 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Logger } from 'winston';
-import { map } from 'rxjs/operators';
-
 import { Guid } from '@dolittle/rudiments';
+import { ProjectionsClient } from '@dolittle/runtime.contracts/Projections/Store_grpc_pb';
+import { GetAllRequest, GetAllResponse, GetOneRequest, GetOneResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
 import { ScopeId } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
+import { callContexts, failures, guids } from '@dolittle/sdk.protobuf';
 import { Cancellation } from '@dolittle/sdk.resilience';
 import { reactiveUnary } from '@dolittle/sdk.services';
-import { callContexts, failures, guids } from '@dolittle/sdk.protobuf';
 import { Constructor } from '@dolittle/types';
-
-import { ProjectionsClient } from '@dolittle/runtime.contracts/Projections/Store_grpc_pb';
-import { GetOneRequest, GetOneResponse, GetAllRequest, GetAllResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
-
-
+import { map } from 'rxjs/operators';
+import { Logger } from 'winston';
 import { Key, ProjectionId } from '..';
-
-import { CurrentState } from './CurrentState';
-import { IProjectionStore } from './IProjectionStore';
-import { IProjectionAssociations } from './IProjectionAssociations';
-import { FailedToGetProjection } from './FailedToGetProjection';
-import { ProjectionsToSDKConverter } from './Converters/ProjectionsToSDKConverter';
 import { IConvertProjectionsToSDK } from './Converters/IConvertProjectionsToSDK';
+import { ProjectionsToSDKConverter } from './Converters/ProjectionsToSDKConverter';
+import { CurrentState } from './CurrentState';
+import { FailedToGetProjection } from './FailedToGetProjection';
 import { FailedToGetProjectionState } from './FailedToGetProjectionState';
+import { IProjectionAssociations } from './IProjectionAssociations';
+import { IProjectionStore } from './IProjectionStore';
 
-export class ProjectionStore implements IProjectionStore {
+
+export class ProjectionStore extends IProjectionStore {
 
     private _converter: IConvertProjectionsToSDK = new ProjectionsToSDKConverter();
 
@@ -34,7 +30,9 @@ export class ProjectionStore implements IProjectionStore {
         private readonly _projectionsClient: ProjectionsClient,
         private readonly _executionContext: ExecutionContext,
         private readonly _projectionAssociations: IProjectionAssociations,
-        private readonly _logger: Logger) {}
+        private readonly _logger: Logger) {
+        super();
+    }
 
 
     /** @inheritdoc */

--- a/Source/services/IReverseCallClient.ts
+++ b/Source/services/IReverseCallClient.ts
@@ -2,12 +2,18 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { ExecutionContext } from '@dolittle/sdk.execution';
-import { Subscribable } from 'rxjs';
+import { PartialObserver, Subscribable, Unsubscribable } from 'rxjs';
 
 export type ReverseCallCallback<TRequest, TResponse> = (request: TRequest, executionContext: ExecutionContext) => TResponse | Promise<TResponse>;
 
 /**
  * Defines a client for reverse calls coming from the server to the client.
  */
-export interface IReverseCallClient<TConnectResponse> extends Subscribable<TConnectResponse> {
+export abstract class IReverseCallClient<TConnectResponse> implements Subscribable<TConnectResponse> {
+    abstract subscribe (observer?: PartialObserver<TConnectResponse>): Unsubscribable;
+    abstract subscribe (next: null | undefined, error: null | undefined, complete: () => void): Unsubscribable;
+    abstract subscribe (next: null | undefined, error: (error: any) => void, complete?: () => void): Unsubscribable;
+    abstract subscribe (next: (value: TConnectResponse) => void, error: null | undefined, complete: () => void): Unsubscribable;
+    abstract subscribe (next?: (value: TConnectResponse) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
+    abstract subscribe (next?: any, error?: any, complete?: any): Unsubscribable;
 }

--- a/Source/services/ReverseCallClient.ts
+++ b/Source/services/ReverseCallClient.ts
@@ -1,28 +1,28 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Subject, Observable, Unsubscribable, NextObserver, ErrorObserver, CompletionObserver, partition, merge, concat, TimeoutError } from 'rxjs';
-import { first, skip, map, filter, timeout } from 'rxjs/operators';
-
-import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
-import { Logger } from 'winston';
-
-import { ReverseCallRequestContext, ReverseCallResponseContext, ReverseCallArgumentsContext } from '@dolittle/contracts/Services/ReverseCallContext_pb';
 import { Ping, Pong } from '@dolittle/contracts/Services/Ping_pb';
-
+import { ReverseCallArgumentsContext, ReverseCallRequestContext, ReverseCallResponseContext } from '@dolittle/contracts/Services/ReverseCallContext_pb';
 import { Guid } from '@dolittle/rudiments';
 import { ExecutionContext } from '@dolittle/sdk.execution';
-import { executionContexts, guids } from '@dolittle/sdk.protobuf';
+import { executionContexts, guids } from '@dolittle/sdk.protobuf';
 import { Cancellation } from '@dolittle/sdk.resilience';
-
+import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
+import { CompletionObserver, concat, ErrorObserver, merge, NextObserver, Observable, partition, Subject, TimeoutError, Unsubscribable } from 'rxjs';
+import { filter, first, map, skip, timeout } from 'rxjs/operators';
+import { Logger } from 'winston';
 import { DidNotReceiveConnectResponse } from './DidNotReceiveConnectResponse';
 import { IReverseCallClient, ReverseCallCallback } from './IReverseCallClient';
 import { PingTimeout } from './PingTimeout';
 
+
+
+
+
 /**
  * Represents an implementation of {IReverseCallClient}.
  */
-export class ReverseCallClient<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> implements IReverseCallClient<TConnectResponse> {
+export class ReverseCallClient<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> extends IReverseCallClient<TConnectResponse> {
     private _observable: Observable<TConnectResponse>;
 
     constructor(
@@ -43,6 +43,7 @@ export class ReverseCallClient<TClientMessage, TServerMessage, TConnectArguments
         private _callback: ReverseCallCallback<TRequest, TResponse>,
         private _cancellation: Cancellation,
         private _logger: Logger) {
+        super();
         this._observable = this.create();
     }
 


### PR DESCRIPTION

## Summary

Changes all `interface` types to `abstract class`. Their naming stays the same, as we're still using them like interfaces. 
The reason for the change is to enable the use of dependency-injection frameworks for TS/JS for developers.
Transpiling TS -> JS strips away all the interfaces, leaving the DI framework with no token to associate with the type.
Changing them to abstract classes generates empty classes (that must not be instantiated in JS), that can be used as binding tokens.

### Changed

- All `interfaces` to `abstract class`.
