### PR TITLE
Setting public to true when applying public events

### DIFF
--- a/Source/aggregates/AggregateRoot.ts
+++ b/Source/aggregates/AggregateRoot.ts
@@ -68,7 +68,7 @@ export class AggregateRoot {
      */
     applyPublic(event: any, eventType?: EventType): void {
         eventType = eventType || EventType.unspecified;
-        this.applyImplementation(event, eventType, false);
+        this.applyImplementation(event, eventType, true);
     }
 
     /**

--- a/Source/aggregates/for_AggregateRoot/when_applying_public_events.ts
+++ b/Source/aggregates/for_AggregateRoot/when_applying_public_events.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { EventSourceId, EventType, EventTypeId, Generation } from '@dolittle/sdk.events';
+import { AggregateRoot } from '../AggregateRoot';
+
+describe('when applying public events', () => {
+    const event = { something: 42 };
+
+    const eventType = new EventType(EventTypeId.from('7b078c73-5843-434e-9b4d-ecae4e91469e'), Generation.first);
+    const aggregateRoot = new AggregateRoot(EventSourceId.from('8f58f9d5-fded-49f3-8334-a3c1f447d4da'));
+    aggregateRoot.applyPublic(event, eventType);
+
+    it('should have one event applied', () => aggregateRoot.appliedEvents.length.should.equal(1));
+    it('should have the event applied be public', () => aggregateRoot.appliedEvents[0].isPublic.should.be.true);
+});

--- a/Source/aggregates/for_Dummy/when_nothing.ts
+++ b/Source/aggregates/for_Dummy/when_nothing.ts
@@ -1,6 +1,0 @@
-// Copyright (c) Dolittle. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-describe('when nothing', () => {
-    it('should be fine', () => true.should.be.true);
-});


### PR DESCRIPTION
## Summary

Fixes `applyPublic()` to actually be public. It was giving false for the `isPublic` parameter for the committing of the event.

### Fixed

- Fixes `applyPublic()` to actually commit public events.
