### PR TITLE
Add embeddings as a prerelease branch

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,7 +1,7 @@
 name: TypeScript Library CI/CD
 
 env:
-  PRERELEASE_BRANCHES: 'projections' # Comma separated list of prerelease branch names. 'alpha,rc, ...'
+  PRERELEASE_BRANCHES: 'embeddings' # Comma separated list of prerelease branch names. 'alpha,rc, ...'
 
 on:
   push:


### PR DESCRIPTION
## Summary

Add the embeddings prerelease branch to GitHub workflow to release embeddings as we go.