### PR TITLE
Pass along ExecutionContext to Container for DI

### DIFF
--- a/Source/common/IContainer.ts
+++ b/Source/common/IContainer.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { ExecutionContext } from '@dolittle/sdk.execution';
 import { Constructor } from '@dolittle/types';
 
 /**
@@ -10,8 +11,9 @@ export abstract class IContainer {
 
     /**
      * Get the instance of a service.
-     * @param {Function} service Type of service by its constructor to get
+     * @param {Constructor} service Type of service by its constructor to get
+     * @param {ExecutionContext} executionContext The current execution context to use for resolving tenant-dependant services.
      * @returns The instance.
      */
-    abstract get (service: Constructor): any;
+    abstract get (service: Constructor, executionContext: ExecutionContext): any;
 }

--- a/Source/common/package.json
+++ b/Source/common/package.json
@@ -32,7 +32,8 @@
         "lint:fix": "gulp lint-fix --gulpfile ../../node_modules/@dolittle/typescript.build/Gulpfile.js"
     },
     "dependencies": {
-        "@dolittle/types": "5.0.1"
+        "@dolittle/types": "5.0.1",
+        "@dolittle/sdk.execution": "14.3.2"
     },
     "devDependencies": {}
 }

--- a/Source/events.handling/Builder/EventHandlerClassBuilder.ts
+++ b/Source/events.handling/Builder/EventHandlerClassBuilder.ts
@@ -23,20 +23,20 @@ import { ICanBuildAndRegisterAnEventHandler } from './ICanBuildAndRegisterAnEven
 
 export class EventHandlerClassBuilder<T> extends ICanBuildAndRegisterAnEventHandler {
     private readonly _eventHandlerType: Constructor<T>;
-    private readonly _getInstance: (container: IContainer) => T;
+    private readonly _getInstance: (container: IContainer, executionContext: ExecutionContext) => T;
 
     constructor(typeOrInstance: Constructor<T> | T) {
         super();
         if (typeOrInstance instanceof Function) {
             this._eventHandlerType = typeOrInstance;
-            this._getInstance = container => container.get(typeOrInstance);
+            this._getInstance = (container, executionContext) => container.get(typeOrInstance, executionContext);
 
         } else {
             this._eventHandlerType = Object.getPrototypeOf(typeOrInstance).constructor;
             if (this._eventHandlerType === undefined) {
                 throw new CannotRegisterEventHandlerThatIsNotAClass(typeOrInstance);
             }
-            this._getInstance = _ => typeOrInstance;
+            this._getInstance = () => typeOrInstance;
         }
     }
 
@@ -104,7 +104,7 @@ export class EventHandlerClassBuilder<T> extends ICanBuildAndRegisterAnEventHand
         return (event, eventContext) => {
             let instance: T;
             try {
-                instance = this._getInstance(container);
+                instance = this._getInstance(container, eventContext.executionContext);
             } catch (ex) {
                 throw new CouldNotCreateInstanceOfEventHandler(this._eventHandlerType, ex);
             }


### PR DESCRIPTION
## Summary

Adds the current `ExecutionContext` as an argument to `IContainer.get(...)` and sends it along from the `EventContext` when instantiating event handler classes.

### Added

- Added `executionContext: ExecutionContext` as an argument in `IContainer.get(...)`.
