### PR TITLE
Rename `embeddings.delete()` to `embeddings.remove()`

### DIFF
--- a/Samples/Tutorials/Embeddings/index.ts
+++ b/Samples/Tutorials/Embeddings/index.ts
@@ -72,15 +72,15 @@ const client = Client
                     .get(DishCounter, counter.dish);
                 console.log('Got dish:', counterState.state);
 
-                console.log(`Deleting dish counter: ${counter}`);
+                console.log(`Removed dish counter: ${counter}`);
                 await client.embeddings
                     .forTenant(TenantId.development)
-                    .delete(DishCounter, counter.dish);
+                    .remove(DishCounter, counter.dish);
 
                 const deletedCounter = await client.embeddings
                     .forTenant(TenantId.development)
                     .get(DishCounter, counter.dish);
-                console.log(`Got a deleted, initial dish counter: ${JSON.stringify(deletedCounter.state)}`);
+                console.log(`Got a removed, initial dish counter: ${JSON.stringify(deletedCounter.state)}`);
             }));
 
         const allDishCounters = await client.embeddings
@@ -110,10 +110,10 @@ const client = Client
             .getAll('999a6aa4-4412-4eaf-a99b-2842cb191e7c');
         console.log(`Got all chefs:\n${[...allChefs].map(([key, value]) => `${key.value}: ${JSON.stringify(value.state, undefined, 2)}`).join('\n')}`);
 
-        console.log('Deleting Mr. Taco!');
+        console.log('Removing Mr. Taco!');
         await client.embeddings
             .forTenant(TenantId.development)
-            .delete(mrTaco.name, '999a6aa4-4412-4eaf-a99b-2842cb191e7c');
+            .remove(mrTaco.name, '999a6aa4-4412-4eaf-a99b-2842cb191e7c');
         const allChefsAgain = await client.embeddings
             .forTenant(TenantId.development)
             .getAll('999a6aa4-4412-4eaf-a99b-2842cb191e7c');
@@ -123,7 +123,7 @@ const client = Client
         const getMrTaco = await client.embeddings
             .forTenant(TenantId.development)
             .get(mrTaco.name, '999a6aa4-4412-4eaf-a99b-2842cb191e7c');
-        console.log('Got deleted Mr. Taco:', getMrTaco.state);
+        console.log('Got removed Mr. Taco:', getMrTaco.state);
 
     }, 1000);
 })();

--- a/Source/embeddings/Embedding.ts
+++ b/Source/embeddings/Embedding.ts
@@ -82,23 +82,23 @@ export class Embedding extends IEmbedding {
     }
 
     /** @inheritdoc */
-    delete<TEmbedding>(
+    remove<TEmbedding>(
         type: Constructor<TEmbedding>,
         key: Key | string,
         cancellation?: Cancellation): Promise<void>;
     /** @inheritdoc */
-    delete(
+    remove(
         key: Key | string,
         embeddingId: EmbeddingId | Guid | string,
         cancellation?: Cancellation): Promise<void>;
-    async delete<TEmbedding = any>(
+    async remove<TEmbedding = any>(
         typeOrKey: Constructor<TEmbedding> | Key | string,
         keyOrEmbeddingId: Key | EmbeddingId | Guid | string,
         maybeCancellation?: Cancellation): Promise<void> {
         const key = this.getKeyFrom(typeOrKey, keyOrEmbeddingId);
         const embedding = this.getEmbeddingForDelete(typeOrKey, keyOrEmbeddingId);
         const cancellation = maybeCancellation || Cancellation.default;
-        this._logger.debug(`Deleting one state from embedding ${embedding} with key ${key}`);
+        this._logger.debug(`Removing one state from embedding ${embedding} with key ${key}`);
 
         const request = new DeleteRequest();
         request.setCallcontext(callContexts.toProtobuf(this._executionContext));

--- a/Source/embeddings/IEmbedding.ts
+++ b/Source/embeddings/IEmbedding.ts
@@ -62,26 +62,26 @@ export abstract class IEmbedding extends EmbeddingStore {
         cancellation?: Cancellation): Promise<CurrentState<any>>;
 
     /**
-     * Deletes an embedding state by key for the embedding associated with a type.
+     * Removes an embedding state by key for the embedding associated with a type.
      * @template TEmbedding
      * @param {Constructor<T>} type The type of the embedding.
      * @param {Key | string} key The key of the embedding.
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<void>}
      */
-    abstract delete<TEmbedding> (
+    abstract remove<TEmbedding> (
         type: Constructor<TEmbedding>,
         key: Key | string,
         cancellation?: Cancellation): Promise<void>;
 
     /**
-     * Deletes an embedding state by key for the embedding specified by the embedding identifier.
+     * Removes an embedding state by key for the embedding specified by the embedding identifier.
      * @param {Key | string} key The key of the embedding.
      * @param {EmbeddingId | Guid | string} embeddingId The id of the embedding.
      * @param {Cancellation} [cancellation] The cancellation token.
      * @returns {Promise<void>}
      */
-    abstract delete (
+    abstract remove (
         key: Key | string,
         embeddingId: EmbeddingId | Guid | string,
         cancellation?: Cancellation): Promise<void>;


### PR DESCRIPTION
## Summary

Renames the call to delete an embedding from`embeddings.delete()` to `embeddings.remove()`, so that it's consistent with the `@remove()` decorator and inline builder naming.

Originally the decorators were also supposed to be called `@delete()`, but as `delete` is a reserved keyword in JS, we changed them to `@remove()`, but didn't think of changing the deletion call too to match. Internally the processor and contracts still call it `delete`, this change only affects the outside facing API.

### Changed

- Change the `embeddings.delete()` call to `embeddings.remove()`.
