### PR TITLE
Adding sdk.embeddings to the sdk

### DIFF
--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -39,6 +39,7 @@
         "@dolittle/sdk.aggregates": "17.0.0",
         "@dolittle/sdk.artifacts": "17.0.0",
         "@dolittle/sdk.common": "17.0.0",
+        "@dolittle/sdk.embeddings": "17.0.0",
         "@dolittle/sdk.eventhorizon": "17.0.0",
         "@dolittle/sdk.events": "17.0.0",
         "@dolittle/sdk.events.handling": "17.0.0",


### PR DESCRIPTION
## Summary

Adding "sdk.embeddings" to the "sdk" package.json.

### Fixed

- Adding sdk.embeddings to sdk, making the npm package include the new embeddings work
