### PR TITLE
Fix eventhandler async methods

### DIFF
--- a/Source/embeddings/Builder/EmbeddingClassBuilder.ts
+++ b/Source/embeddings/Builder/EmbeddingClassBuilder.ts
@@ -161,8 +161,8 @@ export class EmbeddingClassBuilder<T> implements ICanBuildAndRegisterAnEmbedding
     }
 
     private createOnMethod(method: OnDecoratedEmbeddingMethod): EmbeddingProjectCallback<T> {
-        return (instance, event, embeddingProjectionContext) => {
-            const result = method.method.call(instance, event, embeddingProjectionContext);
+        return async (instance, event, embeddingProjectionContext) => {
+            const result = await method.method.call(instance, event, embeddingProjectionContext);
             if (result instanceof DeleteReadModelInstance) {
                 return result;
             }

--- a/Source/embeddings/Internal/EmbeddingDeleteMethodFailed.ts
+++ b/Source/embeddings/Internal/EmbeddingDeleteMethodFailed.ts
@@ -11,9 +11,9 @@ export class EmbeddingDeleteMethodFailed<T> extends Exception {
      * @param {T} receivedState
      * @param {T} currentState
      * @param {EmbeddingContext} context
-     * @param {Error} error
+     * @param {any} error
      */
-     constructor(embeddingId: EmbeddingId, currentState: T, context: EmbeddingContext, error: Error) {
+     constructor(embeddingId: EmbeddingId, currentState: T, context: EmbeddingContext, error: any) {
         super(`The delete method on embedding ${embeddingId} failed to delete key ${context.key}. Current state: ${JSON.stringify(currentState)}. The error was: ${error}`);
     }
 }

--- a/Source/embeddings/Internal/EmbeddingUpdateMethodFailed.ts
+++ b/Source/embeddings/Internal/EmbeddingUpdateMethodFailed.ts
@@ -14,7 +14,7 @@ export class EmbeddingUpdateMethodFailed<T> extends Exception {
      * @param {EmbeddingContext} context
      * @param {Error} error
      */
-    constructor(embeddingId: EmbeddingId, receivedState: T, currentState: T, context: EmbeddingContext, error: Error) {
+    constructor(embeddingId: EmbeddingId, receivedState: T, currentState: T, context: EmbeddingContext, error: any) {
         super(`The update method on embedding ${embeddingId} failed to update read model with key ${context.key}. Received state: ${JSON.stringify(receivedState)}. Current state: ${JSON.stringify(currentState)}The error was: ${error}`);
     }
 }

--- a/Source/events.handling/Builder/CouldNotCreateInstanceOfEventHandler.ts
+++ b/Source/events.handling/Builder/CouldNotCreateInstanceOfEventHandler.ts
@@ -15,9 +15,9 @@ export class CouldNotCreateInstanceOfEventHandler extends Exception {
     /**
      * Initializes an instance of {@link CouldNotCreateInstanceOfEventHandler}.
      * @param {Constructor<any>} type The event handler type to be instantiated.
-     * @param {Exception} inner The inner exception.
+     * @param {any} error The error.
      */
-    constructor(type: Constructor<any>, inner:  Exception) {
-        super(`Could not create an instance of the event handler ${type.name}. ${inner}`);
+    constructor(type: Constructor<any>, error: any) {
+        super(`Could not create an instance of the event handler ${type.name}. ${error}`);
     }
 }

--- a/Source/events.handling/Builder/EventHandlerClassBuilder.ts
+++ b/Source/events.handling/Builder/EventHandlerClassBuilder.ts
@@ -108,7 +108,7 @@ export class EventHandlerClassBuilder<T> extends ICanBuildAndRegisterAnEventHand
             } catch (ex) {
                 throw new CouldNotCreateInstanceOfEventHandler(this._eventHandlerType, ex);
             }
-            method.method.call(instance, event, eventContext);
+            return method.method.call(instance, event, eventContext);
         };
     }
 

--- a/Source/events.handling/Builder/EventHandlerClassBuilder.ts
+++ b/Source/events.handling/Builder/EventHandlerClassBuilder.ts
@@ -105,8 +105,8 @@ export class EventHandlerClassBuilder<T> extends ICanBuildAndRegisterAnEventHand
             let instance: T;
             try {
                 instance = this._getInstance(container, eventContext.executionContext);
-            } catch (ex) {
-                throw new CouldNotCreateInstanceOfEventHandler(this._eventHandlerType, ex);
+            } catch (error) {
+                throw new CouldNotCreateInstanceOfEventHandler(this._eventHandlerType, error);
             }
             return method.method.call(instance, event, eventContext);
         };

--- a/Source/events.processing/Internal/EventProcessor.ts
+++ b/Source/events.processing/Internal/EventProcessor.ts
@@ -62,7 +62,7 @@ export abstract class EventProcessor<TIdentifier extends ConceptAs<Guid, string>
         try {
             retryProcessingState = this.getRetryProcessingStateFromRequest(request);
             return await this.handle(request, executionContext);
-        } catch (error) {
+        } catch (error: any) {
             const failure = new ProcessorFailure();
             failure.setReason(`${error}`);
             failure.setRetry(true);

--- a/Source/projections/Builder/ProjectionClassBuilder.ts
+++ b/Source/projections/Builder/ProjectionClassBuilder.ts
@@ -116,8 +116,8 @@ export class ProjectionClassBuilder<T> implements ICanBuildAndRegisterAProjectio
     }
 
     private createOnMethod(method: OnDecoratedProjectionMethod): ProjectionCallback<T> {
-        return (instance, event, projectionContext) => {
-            const result = method.method.call(instance, event, projectionContext);
+        return async (instance, event, projectionContext) => {
+            const result = await method.method.call(instance, event, projectionContext);
             if (result instanceof DeleteReadModelInstance) {
                 return result;
             }

--- a/Source/protobuf/for_eventTypes/when_converting_from_protobuf_with_missing_id.ts
+++ b/Source/protobuf/for_eventTypes/when_converting_from_protobuf_with_missing_id.ts
@@ -9,7 +9,7 @@ describe('when converting from protobuf with missing id', () => {
     const pbArtifact = new PbArtifact();
     pbArtifact.setGeneration(42);
 
-    let result: Error = {} as Error;
+    let result: any;
 
     try {
         pbArtifact.toSDK();

--- a/Source/protobuf/for_failures/when_converting_from_protobuf_with_missing_id.ts
+++ b/Source/protobuf/for_failures/when_converting_from_protobuf_with_missing_id.ts
@@ -10,7 +10,7 @@ describe('when converting from protobuf with missing id', () => {
     const pbArtifact = new PbFailure();
     pbArtifact.setReason(reason);
 
-    let result: Error = {} as Error;
+    let result: any;
 
     try {
         pbArtifact.toSDK();


### PR DESCRIPTION
## Summary

Fixes a bug where `async` Event Handler methods were not properly awaited (and thus also exceptions ignored) if they did any async work. In the process, also found a bug related to _delete results_ returned from async Projection and Embedding methods, that would not be handled correctly.

### Fixed

- Return the `Promise` from Event Handler methods in the EventHandlerClassBuilder to handle async methods properly.
- Await results from Projection/Embedding `on()` methods, so that async _delete results_ are handled properly.