### PR TITLE
Fix-on-event

### DIFF
--- a/.github/workflows/ms-teams-release.yml
+++ b/.github/workflows/ms-teams-release.yml
@@ -3,7 +3,7 @@ name: Microsoft Teams Release Notification
 on:
   release:
     types:
-      - released
+      - published
 
 jobs:
   notify:


### PR DESCRIPTION
## Summary

Uses the correct release event type

### Fixed

- Use the correct release event type, 'published' 