### PR TITLE
Add readme to packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ package-lock.json
 Samples/**/data
 Source/**/Distribution
 Samples/**/Distribution
+Source/**/README.md

--- a/Assets/copy-readme.js
+++ b/Assets/copy-readme.js
@@ -23,7 +23,14 @@ const fs = require('fs');
 
     for (const destination of destinations) {
         const destinationPath = path.resolve(destination, 'README.md');
-        fs.writeFile(destinationPath, readmeFile);
+        await new Promise((reject, resolve) =>
+            fs.writeFile(destinationPath, readmeFile, (error) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve();
+                }
+            }));
     }
 })().catch(error => {
     console.error(error);

--- a/Assets/copy-readme.js
+++ b/Assets/copy-readme.js
@@ -9,6 +9,7 @@ const fs = require('fs');
     const readmeFile = await new Promise((resolve, reject) =>
         fs.readFile(readmePath, (error, data) => {
             if (error) {
+                console.error('Failed to open README from', readmePath);
                 reject(error);
             } else {
                 resolve(data);
@@ -26,6 +27,7 @@ const fs = require('fs');
         await new Promise((reject, resolve) =>
             fs.writeFile(destinationPath, readmeFile, (error) => {
                 if (error) {
+                    console.error('Failed to copy to', destinationPath, error);
                     reject(error);
                 } else {
                     resolve();

--- a/Assets/copy-readme.js
+++ b/Assets/copy-readme.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const fs = require('fs');
 
-(async () => {
+await (async () => {
     const readmePath = path.resolve(__dirname, '..', 'README.md');
     const readmeFile = await new Promise((resolve, reject) =>
         fs.readFile(readmePath, (error, data) => {

--- a/Assets/copy-readme.js
+++ b/Assets/copy-readme.js
@@ -2,11 +2,18 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 const path = require('path');
-const fs = require('fs/promises');
+const fs = require('fs');
 
 (async () => {
     const readmePath = path.resolve(__dirname, '..', 'README.md');
-    const readmeFile = await fs.readFile(readmePath);
+    const readmeFile = await new Promise((resolve, reject) =>
+        fs.readFile(readmePath, (error, data) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(data);
+            }
+        }));
 
     const destinations = process.argv.slice(2);
 

--- a/Assets/copy-readme.js
+++ b/Assets/copy-readme.js
@@ -24,7 +24,7 @@ const fs = require('fs');
 
     for (const destination of destinations) {
         const destinationPath = path.resolve(destination, 'README.md');
-        await new Promise((reject, resolve) =>
+        await new Promise((resolve, reject) =>
             fs.writeFile(destinationPath, readmeFile, (error) => {
                 if (error) {
                     console.error('Failed to copy to', destinationPath, error);

--- a/Assets/copy-readme.js
+++ b/Assets/copy-readme.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const fs = require('fs');
 
-await (async () => {
+(async () => {
     const readmePath = path.resolve(__dirname, '..', 'README.md');
     const readmeFile = await new Promise((resolve, reject) =>
         fs.readFile(readmePath, (error, data) => {
@@ -25,4 +25,7 @@ await (async () => {
         const destinationPath = path.resolve(destination, 'README.md');
         fs.writeFile(destinationPath, readmeFile);
     }
-})();
+})().catch(error => {
+    console.error(error);
+    process.exit(1);
+});

--- a/Assets/copy-readme.js
+++ b/Assets/copy-readme.js
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+const path = require('path');
+const fs = require('fs/promises');
+
+(async () => {
+    const readmePath = path.resolve(__dirname, '..', 'README.md');
+    const readmeFile = await fs.readFile(readmePath);
+
+    const destinations = process.argv.slice(2);
+
+    if (destinations.length < 1) {
+        throw new Error('No desitionations specified to copy the README.md file to.');
+    }
+
+    for (const destination of destinations) {
+        const destinationPath = path.resolve(destination, 'README.md');
+        fs.writeFile(destinationPath, readmeFile);
+    }
+})();

--- a/Source/aggregates/package.json
+++ b/Source/aggregates/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/artifacts/package.json
+++ b/Source/artifacts/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/common/package.json
+++ b/Source/common/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/embeddings/package.json
+++ b/Source/embeddings/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/eventHorizon/package.json
+++ b/Source/eventHorizon/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/events.filtering/package.json
+++ b/Source/events.filtering/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/events.handling/package.json
+++ b/Source/events.handling/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/execution/package.json
+++ b/Source/execution/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/projections/package.json
+++ b/Source/projections/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/protobuf/package.json
+++ b/Source/protobuf/package.json
@@ -23,10 +23,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/resilience/package.json
+++ b/Source/resilience/package.json
@@ -23,10 +23,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/resources/package.json
+++ b/Source/resources/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -23,10 +23,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -23,10 +23,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/Source/tenancy/package.json
+++ b/Source/tenancy/package.json
@@ -22,10 +22,11 @@
     "main": "Distribution/index.js",
     "types": "Distribution/index.d.ts",
     "scripts": {
-        "prebuild": "yarn clean",
+        "prebuild": "yarn clean && yarn copy-readme",
         "postbuild": "yarn lint",
         "build": "tsc -b",
         "clean": "tsc -b --clean",
+        "copy-readme": "node ../../Assets/copy-readme.js .",
         "test": "mocha",
         "lint": "eslint --quiet --ext .ts ./",
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "Samples/Container"
   ],
   "scripts": {
-    "prebuild": "yarn clean",
+    "prebuild": "yarn clean && yarn copy-readme",
     "postbuild": "yarn lint",
     "build": "tsc -b Source/tsconfig.json && tsc -b Samples/tsconfig.json",
     "clean": "tsc -b Source/tsconfig.json --clean && tsc -b Samples/tsconfig.json --clean",
     "test": "TS_NODE_PROJECT=tsconfig.settings.json mocha",
+    "copy-readme": "node Assets/copy-readme.js Source/*/",
     "test:clean": "rimraf **/Distribution/**/for_*",
     "lint": "eslint --quiet --ext .ts ./",
     "lint:fix": "eslint --quiet --ext .ts ./ --fix",


### PR DESCRIPTION
## Summary

Introducing a new build script that copies over the README.md file to the root of each project to be packaged and published to npm.

### Added

- Build script that copies the README.md file to the root of each package before building
