### PR TITLE
Custom nom package README

### DIFF
--- a/Assets/PACKAGE-README.md
+++ b/Assets/PACKAGE-README.md
@@ -1,0 +1,20 @@
+![Dolittle](https://raw.githubusercontent.com/dolittle/Runtime/master/Documentation/dolittle_negativ_horisontal_RGB.svg "Dolittle")
+
+Dolittle is a decentralized, distributed, event-driven microservice platform built to harness the power of events.
+
+This is our JavaScript and TypeScript SDK, install it with:
+```shell
+$ npm install @dolittle/sdk 
+```
+
+# Get Started
+- Try our [getting started tutorial](https://dolittle.io/docs/tutorials/getting_started/)
+- Check out our [documentation](https://dolittle.io)
+
+# Want to try another language?
+- Check out the [.NET SDK](https://github.com/dolittle/DotNet.SDK)
+
+# Issues and Contributing
+Issues and contributions are always welcome!
+
+To learn how to contribute, please read our [contributing](https://dolittle.io/docs/contributing/) guide.

--- a/Assets/copy-readme.js
+++ b/Assets/copy-readme.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fs = require('fs');
 
 (async () => {
-    const readmePath = path.resolve(__dirname, '..', 'README.md');
+    const readmePath = path.resolve(__dirname, 'PACKAGE-README.md');
     const readmeFile = await new Promise((resolve, reject) =>
         fs.readFile(readmePath, (error, data) => {
             if (error) {


### PR DESCRIPTION
## Summary

Use a custom README file for publishing to npmjs. To keep it consistent with the C# SDK - and we don't need all that building stuff for NPM.

### Changed

- The published README file.
