### PR TITLE
Fix magic numbers in VersionInfo

### DIFF
--- a/Source/sdk/VersionInfo.ts
+++ b/Source/sdk/VersionInfo.ts
@@ -11,6 +11,6 @@ export class VersionInfo {
      * Gets the current {@link Version} of the Dolittle JS SDK.
      */
     static get currentVersion(): Version {
-        return new Version(21, 0, 0, 0, 'gimli.3');
+        return new Version(377, 389, 368, 0, 'PRERELEASE');
     }
 }


### PR DESCRIPTION
## Summary

These numbers should not be changed. They were committed by the `release-typescript-lib-action`, but they should not. The action has also been patched to fix this behaviour: https://github.com/dolittle/release-typescript-lib-action/pull/24

### Fixed

- Magic numbers in `VersionInfo.ts`
