### PR TITLE
Implement handshake

### DIFF
--- a/Source/dependencyInversion/TenantServiceProviders.ts
+++ b/Source/dependencyInversion/TenantServiceProviders.ts
@@ -33,7 +33,7 @@ export class TenantServiceProviders extends ITenantServiceProviders {
     constructor(
         baseServiceProvider: IServiceProvider,
         bindings: IServiceProviderBuilder,
-        tenants: TenantId[],
+        tenants: readonly TenantId[],
     ) {
         super();
 

--- a/Source/sdk/DolittleClient.ts
+++ b/Source/sdk/DolittleClient.ts
@@ -26,11 +26,11 @@ import { EventHorizons, IEventHorizons, SubscriptionCallbacks, TenantWithSubscri
 import { EventStoreBuilder, IEventStore, IEventStoreBuilder, IEventTypes, Internal as EventTypesInternal } from '@dolittle/sdk.events';
 import { Filters, IFilterProcessor } from '@dolittle/sdk.events.filtering';
 import { EventHandlers, Internal as EventsHandlingInternal } from '@dolittle/sdk.events.handling';
-import { Claims, CorrelationId, Environment, ExecutionContext, MicroserviceId, TenantId, Version } from '@dolittle/sdk.execution';
+import { ExecutionContext } from '@dolittle/sdk.execution';
 import { IProjectionStoreBuilder, ProjectionAssociations, Projections, ProjectionStoreBuilder, Internal as ProjectionsInternal, IProjectionStore } from '@dolittle/sdk.projections';
 import { Cancellation, CancellationSource } from '@dolittle/sdk.resilience';
 import { IResources, IResourcesBuilder, ResourcesBuilder } from '@dolittle/sdk.resources';
-import { Tenant, Internal as TenancyInternal } from '@dolittle/sdk.tenancy';
+import { Tenant } from '@dolittle/sdk.tenancy';
 
 import { ConfigurationBuilder } from './Builders/ConfigurationBuilder';
 import { ConnectCallback } from './Builders/ConnectCallback';

--- a/Source/sdk/DolittleClient.ts
+++ b/Source/sdk/DolittleClient.ts
@@ -42,6 +42,7 @@ import { CannotUseUnconnectedDolittleClient } from './CannotUseUnconnectedDolitt
 import { DolittleClientConfiguration } from './DolittleClientConfiguration';
 import { IDolittleClient } from './IDolittleClient';
 import { ITrackProcessors, ProcessorTracker } from '@dolittle/sdk.services';
+import { RuntimeConnector } from './Internal/RuntimeConnector';
 
 /**
  * Represents the client for working with the Dolittle Runtime.
@@ -55,7 +56,7 @@ export class DolittleClient extends IDolittleClient {
     private _aggregates?: AggregatesBuilder;
     private _projectionStore?: ProjectionStoreBuilder;
     private _embeddingStore?: Embeddings;
-    private _tenants: Tenant[] = [];
+    private _tenants: readonly Tenant[] = [];
     private _resources?: ResourcesBuilder;
     private _services?: TenantServiceProviders;
     private _eventHorizons?: IEventHorizons;
@@ -198,11 +199,14 @@ export class DolittleClient extends IDolittleClient {
 
             const clients = this.createGrpcClients(configuration.runtimeHost, configuration.runtimePort);
 
-            const executionContext = await this.performHandshake(clients.handshake, configuration.version, cancellation);
+            const connector = new RuntimeConnector(
+                clients.handshake,
+                clients.tenants,
+                configuration.version,
+                logger);
 
-            const tenants = new TenancyInternal.Tenants(clients.tenants, executionContext, logger);
-            this._tenants = await tenants.getAll();
-            const tenantIds = this._tenants.map(_ => _.id);
+            const connectionResult = await connector.connect(cancellation);
+            this._tenants = connectionResult.tenants;
 
             this.buildClientServices(
                 clients.eventStore,
@@ -210,13 +214,13 @@ export class DolittleClient extends IDolittleClient {
                 clients.embeddingStore,
                 clients.embeddings,
                 clients.resources,
-                executionContext,
+                connectionResult.executionContext,
                 logger);
 
             this.registerTypes(
                 clients.eventTypes,
                 clients.aggregateRoots,
-                executionContext,
+                connectionResult.executionContext,
                 logger,
                 this._cancellationSource.cancellation);
 
@@ -227,7 +231,7 @@ export class DolittleClient extends IDolittleClient {
             this._services = new TenantServiceProviders(
                 configuration.serviceProvider,
                 this._serviceProviderBuilder,
-                tenantIds);
+                connectionResult.tenantIds);
 
             this.startReverseCallClients(
                 clients.filters,
@@ -235,7 +239,7 @@ export class DolittleClient extends IDolittleClient {
                 clients.projections,
                 clients.embeddings,
                 clients.eventHorizons,
-                executionContext,
+                connectionResult.executionContext,
                 this._services,
                 logger,
                 configuration.pingInterval,
@@ -245,18 +249,6 @@ export class DolittleClient extends IDolittleClient {
             this._connected = false;
             throw exception;
         }
-    }
-
-    private async performHandshake(client: HandshakeClient, version: Version, cancellation: Cancellation): Promise<ExecutionContext> {
-        // TODO: Connect to the runtime and fetch the information
-
-        return new ExecutionContext(
-            MicroserviceId.notApplicable,
-            TenantId.system,
-            version,
-            Environment.undetermined,
-            CorrelationId.system,
-            Claims.empty);
     }
 
     private buildClientServices(

--- a/Source/sdk/IDolittleClient.ts
+++ b/Source/sdk/IDolittleClient.ts
@@ -51,7 +51,7 @@ export abstract class IDolittleClient {
     /**
      * Gets the list of {@link Tenant} that is configured.
      */
-    abstract get tenants(): Tenant[];
+    abstract get tenants(): readonly Tenant[];
 
     /**
      * Gets the {@link IResourcesBuilder}.

--- a/Source/sdk/Internal/ConnectionResult.ts
+++ b/Source/sdk/Internal/ConnectionResult.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ExecutionContext, TenantId } from '@dolittle/sdk.execution';
+import { Tenant } from '@dolittle/sdk.tenancy';
+
+/**
+ * Represents the result of the initial connection to a Dolittle Runtime.
+ */
+export class ConnectionResult {
+    /**
+     * Initialises a new instance of the {@link ConnectionResult} class.
+     * @param {ExecutionContext} executionContext - The root execution context to use for the client.
+     * @param {Tenant[]} tenants - The tenants configured for the client.
+     * @param {TenantId[]} tenantIds - The tenant ids configured for the client.
+     */
+    constructor(
+        readonly executionContext: ExecutionContext,
+        readonly tenants: readonly Tenant[],
+        readonly tenantIds: readonly TenantId[],
+    ) {}
+}

--- a/Source/sdk/Internal/ICanConnectToARuntime.ts
+++ b/Source/sdk/Internal/ICanConnectToARuntime.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Cancellation } from '@dolittle/sdk.resilience';
+
+import { ConnectionResult } from './ConnectionResult';
+
+/**
+ * Defines a system that can perform the initial connection to a Dolittle Runtime.
+ */
+export abstract class ICanConnectToARuntime {
+    /**
+     * Performs the initial connection to the Runtime.
+     * @param {Cancellation} [cancellation] - An optional cancellelation to stop the connection.
+     * @returns {Promise<ConnectionResult>} A promise that, when resolved returns the connection result.
+     */
+    abstract connect(cancellation?: Cancellation): Promise<ConnectionResult>;
+}

--- a/Source/sdk/Internal/RuntimeConnector.ts
+++ b/Source/sdk/Internal/RuntimeConnector.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Logger } from 'winston';
+
+import { Version } from '@dolittle/sdk.execution';
+import { Cancellation } from '@dolittle/sdk.resilience';
+
+import { HandshakeClient } from '@dolittle/runtime.contracts/Handshake/Handshake_grpc_pb';
+import { TenantsClient } from '@dolittle/runtime.contracts/Tenancy/Tenants_grpc_pb';
+
+import { ConnectionResult } from './ConnectionResult';
+import { ICanConnectToARuntime } from './ICanConnectToARuntime';
+
+/**
+ * Represents an implementation of {@link ICanConnectToARuntime}.
+ */
+export class RuntimeConnector extends ICanConnectToARuntime {
+    /**
+     * Initialises a new instance of the {@link RuntimeConnector} class.
+     * @param {HandshakeClient} _handshakeClient - The client to use to perform the handshake.
+     * @param {TenantsClient} _tenantsClient - The client to use for fetching the configured tenants.
+     * @param {Version} _headVersion - The version of the head to use in the handshake.
+     * @param {Logger} _logger - To use for logging.
+     */
+    constructor(
+        private readonly _handshakeClient: HandshakeClient,
+        private readonly _tenantsClient: TenantsClient,
+        private readonly _headVersion: Version,
+        private readonly _logger: Logger,
+    ) {
+        super();
+    }
+
+    /** @inheritdoc */
+    async connect(cancellation: Cancellation = Cancellation.default): Promise<ConnectionResult> {
+        throw new Error('Method not implemented.');
+    }
+
+}

--- a/Source/sdk/Internal/RuntimeConnector.ts
+++ b/Source/sdk/Internal/RuntimeConnector.ts
@@ -2,15 +2,26 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Logger } from 'winston';
+import { from, Notification, Observable } from 'rxjs';
+import { status as GrpcStatus } from '@grpc/grpc-js';
 
-import { Version } from '@dolittle/sdk.execution';
-import { Cancellation } from '@dolittle/sdk.resilience';
+import { Claims, CorrelationId, Environment, ExecutionContext, MicroserviceId, TenantId, Version } from '@dolittle/sdk.execution';
+import { Cancellation, RetryPolicy, retryWithPolicy } from '@dolittle/sdk.resilience';
 
 import { HandshakeClient } from '@dolittle/runtime.contracts/Handshake/Handshake_grpc_pb';
 import { TenantsClient } from '@dolittle/runtime.contracts/Tenancy/Tenants_grpc_pb';
 
 import { ConnectionResult } from './ConnectionResult';
 import { ICanConnectToARuntime } from './ICanConnectToARuntime';
+import { concatMap, delay, dematerialize, map } from 'rxjs/operators';
+import { isGrpcError, reactiveUnary } from '@dolittle/sdk.services';
+import { VersionInfo as ContractsVersionInfo } from '@dolittle/runtime.contracts/VersionInfo';
+import { HandshakeRequest, HandshakeResponse } from '@dolittle/runtime.contracts/Handshake/Handshake_pb';
+import { RuntimeHandshakeFailed } from '../RuntimeHandshakeFailed';
+import { RuntimeVersionNotCompatible } from '../RuntimeVersionNotCompatible';
+import { Failures, Guids, Versions } from '@dolittle/sdk.protobuf';
+import { VersionInfo } from '../VersionInfo';
+import { Tenants } from '@dolittle/sdk.tenancy/Internal/Tenants';
 
 /**
  * Represents an implementation of {@link ICanConnectToARuntime}.
@@ -34,7 +45,95 @@ export class RuntimeConnector extends ICanConnectToARuntime {
 
     /** @inheritdoc */
     async connect(cancellation: Cancellation = Cancellation.default): Promise<ConnectionResult> {
-        throw new Error('Method not implemented.');
+        return retryWithPolicy(
+            this.createConnectCall(cancellation),
+            this.createRetryPolicy(),
+            cancellation)
+        .toPromise();
     }
 
+    private createConnectCall(cancellation: Cancellation): Observable<ConnectionResult> {
+        const startTime = Date.now();
+        let attempt = 0;
+
+        return new Observable((subscriber) => {
+            const timeSinceStart = Date.now() - startTime;
+            attempt += 1;
+
+            const handshake = reactiveUnary(
+                this._handshakeClient,
+                this._handshakeClient.handshake,
+                this.createHandshakeRequest(attempt, timeSinceStart),
+                cancellation)
+            .pipe(map((response) => {
+                if (response.hasFailure()) {
+                    const failure = Failures.toSDK(response.getFailure()!);
+                    throw new RuntimeHandshakeFailed(failure.reason);
+                    // TODO: Handle incompatible versions failure ID
+                }
+
+                return this.createExecutionContextFrom(response);
+            }))
+            .pipe(concatMap((executionContext) => {
+                const tenants = new Tenants(this._tenantsClient, executionContext, this._logger);
+
+                return from(tenants.getAll(cancellation))
+                .pipe(map((tenants) => {
+                    return new ConnectionResult(
+                        executionContext,
+                        tenants,
+                        tenants.map(_ => _.id));
+                }));
+            }));
+
+            handshake.subscribe(subscriber);
+        });
+    }
+
+    private createRetryPolicy(): RetryPolicy {
+        return (errors) => errors.pipe(
+            delay(1000),
+            map((error) => {
+                if (isGrpcError(error) && error.code === GrpcStatus.UNIMPLEMENTED) {
+                    return Notification.createError<Error>(RuntimeVersionNotCompatible.unimplemented);
+                } else if (error instanceof RuntimeVersionNotCompatible) {
+                    return Notification.createError<Error>(error);
+                }
+
+                this._logger.warn(`Connection to Runtime failed, will retry in 1 second. Reason: ${error.message}`);
+                return Notification.createNext(error);
+            }),
+            dematerialize(),
+        );
+    }
+
+    private createHandshakeRequest(attempt: number, millisecondsSinceStart: number): HandshakeRequest {
+        const handshakeRequest = new HandshakeRequest();
+
+        handshakeRequest.setSdk('JS.SDK');
+        handshakeRequest.setHeadversion(Versions.toProtobuf(this._headVersion));
+        handshakeRequest.setSdkversion(Versions.toProtobuf(VersionInfo.currentVersion));
+        handshakeRequest.setContractsversion(ContractsVersionInfo.getCurrentVersion());
+
+        // TODO: Add attempt and time since start to request
+
+        return handshakeRequest;
+    }
+
+    private createExecutionContextFrom(response: HandshakeResponse): ExecutionContext {
+        const runtimeVersion = Versions.toSDK(response.getRuntimeversion());
+        const contractsVersion = Versions.toSDK(response.getContractsversion());
+        this._logger.debug(`Received initial booting configuration from Runtime running version ${runtimeVersion} using Contracts version ${contractsVersion}`);
+
+        const microserviceId = MicroserviceId.from(Guids.toSDK(response.getMicroserviceid()));
+        const environment = Environment.from(response.getEnvironment());
+
+        return new ExecutionContext(
+            microserviceId,
+            TenantId.system,
+            this._headVersion,
+            environment,
+            CorrelationId.system,
+            Claims.empty);
+    }
 }

--- a/Source/sdk/RuntimeHandshakeFailed.ts
+++ b/Source/sdk/RuntimeHandshakeFailed.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { FailureReason } from '@dolittle/sdk.protobuf';
+
+/**
+ * The exception that gets thrown when the handshake with the Runtime fails.
+ */
+export class RuntimeHandshakeFailed extends Error {
+    /**
+     * Initialises a new instance of the {@link RuntimeHandshakeFailed} class.
+     * @param {FailureReason} reason - The reason why the handshake failed.
+     */
+    constructor(reason: FailureReason) {
+        super(`Runtime handhshake failed beacause ${reason.value}`);
+    }
+}

--- a/Source/sdk/RuntimeHandshakeMissingInformation.ts
+++ b/Source/sdk/RuntimeHandshakeMissingInformation.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * The exception that gets thrown when the Runtime returns an incomplete handshake response.
+ */
+export class RuntimeHandshakeMissingInformation extends Error {
+    /**
+     * Initialises a new instance of the {@link RuntimeHandshakeMissingInformation} class.
+     * @param {string} missing - The missing information.
+     */
+    constructor(missing: string) {
+        super(`The handshake response from the Runtime is missing ${missing}`);
+    }
+}

--- a/Source/sdk/RuntimeVersionNotCompatible.ts
+++ b/Source/sdk/RuntimeVersionNotCompatible.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IDolittleClient } from './IDolittleClient';
+import { VersionInfo } from './VersionInfo';
+
+/**
+ * The exception that gets thrown when trying to connect the {@link IDolittleClient} to a Runtime that is not compatible with this version of the SDK.
+ */
+export class RuntimeVersionNotCompatible extends Error {
+    /**
+     * Initialises a new instance of the {@link RuntimeVersionNotCompatible} class.
+     * @param {string} fix - The message that describes how to fix the issue.
+     */
+    constructor(fix: string) {
+        super(`This version of the SDK (${VersionInfo.currentVersion}) is not compatible with the Dolittle Runtime you are connecting to. ${fix}.`);
+    }
+
+    /**
+     * The exception to throw when the Runtime returns an unimplemented exception during the handshake.
+     */
+    static get unimplemented(): RuntimeVersionNotCompatible {
+        return new RuntimeVersionNotCompatible('Please upgrade the Runtime to version 7.4.0 or later');
+    }
+}

--- a/Source/sdk/_exports.ts
+++ b/Source/sdk/_exports.ts
@@ -6,4 +6,6 @@ export { CannotUseUnconnectedDolittleClient } from './CannotUseUnconnectedDolitt
 export { DolittleClient } from './DolittleClient';
 export { DolittleClientConfiguration } from './DolittleClientConfiguration';
 export { IDolittleClient } from './IDolittleClient';
+export { RuntimeHandshakeFailed } from './RuntimeHandshakeFailed';
+export { RuntimeVersionNotCompatible } from './RuntimeVersionNotCompatible';
 export { VersionInfo } from './VersionInfo';

--- a/Source/sdk/_exports.ts
+++ b/Source/sdk/_exports.ts
@@ -7,5 +7,6 @@ export { DolittleClient } from './DolittleClient';
 export { DolittleClientConfiguration } from './DolittleClientConfiguration';
 export { IDolittleClient } from './IDolittleClient';
 export { RuntimeHandshakeFailed } from './RuntimeHandshakeFailed';
+export { RuntimeHandshakeMissingInformation } from './RuntimeHandshakeMissingInformation';
 export { RuntimeVersionNotCompatible } from './RuntimeVersionNotCompatible';
 export { VersionInfo } from './VersionInfo';

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -63,6 +63,7 @@
         "@dolittle/sdk.resources": "21.0.0-gimli.7",
         "@dolittle/sdk.services": "21.0.0-gimli.7",
         "@dolittle/sdk.tenancy": "21.0.0-gimli.7",
+        "rxjs": "6.6.0",
         "winston": "3.3.2"
     }
 }

--- a/Source/services/CouldNotConnectToRuntime.ts
+++ b/Source/services/CouldNotConnectToRuntime.ts
@@ -13,6 +13,13 @@ export class CouldNotConnectToRuntime extends Exception {
      * @param {string} address - The address of the Runtime that was connected to.
      */
     constructor(address: string) {
-        super(`Could not connect to a Runtime on '${address}'. Please make sure a Runtime is running, and that the private port (usually 50053) is accessible on the specified port.`);
+        super(`Could not connect to a Runtime on '${CouldNotConnectToRuntime.getStrippedAddress(address)}'. Please make sure a Runtime is running, and that the private port (usually 50053) is accessible on the specified port.`);
+    }
+
+    private static getStrippedAddress(address: string): string {
+        if (address.startsWith('dns:')) {
+            return address.slice(4);
+        }
+        return address;
     }
 }

--- a/Source/services/GrpcError.ts
+++ b/Source/services/GrpcError.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as grpc from '@grpc/grpc-js';
+
+/**
+ * Defines an error thrown from the gRPC library.
+ */
+export interface GrpcError extends Error, grpc.StatusObject {}
+
+/**
+ * Checks whether the given error is a {@link GrpcError} or not.
+ * @param {any} error - The error to check.
+ * @returns {boolean} True if the error is a {@link GrpcError}, false if not.
+ */
+export function isGrpcError(error: any): error is GrpcError {
+    if (typeof error.code !== 'number') return false;
+    if (typeof error.details !== 'string') return false;
+    if (!(error.metadata instanceof grpc.Metadata)) return false;
+    if (!(error instanceof Error)) return false;
+
+    return true;
+}

--- a/Source/services/_exports.ts
+++ b/Source/services/_exports.ts
@@ -4,6 +4,7 @@
 export { ClientProcessor } from './ClientProcessor';
 export { CouldNotConnectToRuntime } from './CouldNotConnectToRuntime';
 export { DidNotReceiveConnectResponse } from './DidNotReceiveConnectResponse';
+export { GrpcError, isGrpcError } from './GrpcError';
 export { ClientStreamMethod, DuplexMethod, ServerStreamMethod, UnaryMethod } from './GrpcMethods';
 export { IReverseCallClient, ReverseCallCallback } from './IReverseCallClient';
 export { ITrackProcessors } from './ITrackProcessors';


### PR DESCRIPTION
## Summary

Implement the handshake with the Runtime, using a new `RuntimeConnector` that performs this operation and fetches the configured tenants.

### Added

- `RuntimeConnector` for performing the initial connection with retries and back-offs (until cancelled or error is incompatible versions).
- A GrpcError interface and typeguard to simplify checking for errors from the gRPC livrary

### Changed

- Removed the `dns:` prefix in the CouldNotConnectToRuntime error message.
- The SDK now performs the handshake to get the microservice ID and environment from the Runtime to setup the root ExecutionContext.