### PR TITLE
Fix processing execution context

### DIFF
--- a/Source/embeddings/Internal/EmbeddingProcessor.ts
+++ b/Source/embeddings/Internal/EmbeddingProcessor.ts
@@ -112,8 +112,15 @@ export class EmbeddingProcessor<TReadModel> extends ClientProcessor<EmbeddingId,
         return response.getFailure();
     }
 
-    /** @inheritdoc */
-    protected async handle(request: EmbeddingRequest, executionContext: ExecutionContext, services: IServiceProvider, logger: Logger): Promise<EmbeddingResponse> {
+    /**
+     * Handles the request from the Runtime.
+     * @param {EmbeddingRequest} request - The request from the Runtime.
+     * @param {ExecutionContext} executionContext - The execution context for the current processing request.
+     * @param {IServiceProvider} services - The service provider to use for resolving services while handling the current request.
+     * @param {Logger} logger - The logger to use for logging.
+     * @returns {Promise<EmbeddingResponse>} The response to the request.
+     */
+    async handle(request: EmbeddingRequest, executionContext: ExecutionContext, services: IServiceProvider, logger: Logger): Promise<EmbeddingResponse> {
         const projectionCurrentState = this.getProjectionCurrentState(request);
         const projectionType = projectionCurrentState.getType();
         const projectionKey = projectionCurrentState.getKey();

--- a/Source/events.filtering/Internal/FilterEventProcessor.ts
+++ b/Source/events.filtering/Internal/FilterEventProcessor.ts
@@ -7,7 +7,7 @@ import { DateTime } from 'luxon';
 import { IServiceProvider } from '@dolittle/sdk.dependencyinversion';
 import { EventContext, IEventTypes, EventSourceId, EventType } from '@dolittle/sdk.events';
 import { Internal, MissingEventInformation } from '@dolittle/sdk.events.processing';
-import { Artifacts } from '@dolittle/sdk.protobuf';
+import { Artifacts, ExecutionContexts } from '@dolittle/sdk.protobuf';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 
 import { Failure } from '@dolittle/contracts/Protobuf/Failure_pb';
@@ -73,6 +73,7 @@ export abstract class FilterEventProcessor<TRegisterArguments, TResponse> extend
             pbSequenceNumber,
             EventSourceId.from(pbEventSourceId),
             DateTime.fromJSDate(pbOccurred.toDate()),
+            ExecutionContexts.toSDK(pbExecutionContext),
             executionContext);
 
         let event = JSON.parse(pbEvent.getContent());

--- a/Source/events.handling/Internal/EventHandlerProcessor.ts
+++ b/Source/events.handling/Internal/EventHandlerProcessor.ts
@@ -8,7 +8,7 @@ import { IServiceProvider } from '@dolittle/sdk.dependencyinversion';
 import { EventContext, IEventTypes, EventSourceId, EventType } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { Internal, MissingEventInformation } from '@dolittle/sdk.events.processing';
-import { Artifacts, Guids } from '@dolittle/sdk.protobuf';
+import { Artifacts, ExecutionContexts, Guids } from '@dolittle/sdk.protobuf';
 import { Cancellation } from '@dolittle/sdk.resilience';
 import { IReverseCallClient, ReverseCallClient, reactiveDuplex } from '@dolittle/sdk.services';
 
@@ -136,6 +136,7 @@ export class EventHandlerProcessor extends Internal.EventProcessor<EventHandlerI
             pbSequenceNumber,
             EventSourceId.from(pbEventSourceId),
             DateTime.fromJSDate(pbOccurred.toDate()),
+            ExecutionContexts.toSDK(pbExecutionContext),
             executionContext);
 
         let event = JSON.parse(pbEvent.getContent());

--- a/Source/events.processing/Internal/EventProcessor.ts
+++ b/Source/events.processing/Internal/EventProcessor.ts
@@ -22,6 +22,7 @@ import { IEventProcessor } from './IEventProcessor';
  * Partial implementation of {@link IEventProcessor}.
  * @template TIdentifier The type of the event processor identifier.
  * @template TRequest The type of the event processor requests.
+ * @template TResponse The type of the event processor response.
  */
 export abstract class EventProcessor<TIdentifier extends ConceptAs<Guid, string>, TClient extends grpc.Client, TRegisterArguments, TRegisterResponse, TRequest, TResponse> extends ClientProcessor<TIdentifier, TClient, TRegisterArguments, TRegisterResponse, TRequest, TResponse> implements IEventProcessor<TClient> {
     /**
@@ -64,7 +65,14 @@ export abstract class EventProcessor<TIdentifier extends ConceptAs<Guid, string>
      */
     protected abstract createResponseFromFailure(failure: ProcessorFailure): TResponse;
 
-    /** @inheritdoc */
+    /**
+     * Handles the request from the Runtime.
+     * @param {TRequest} request - The request from the Runtime.
+     * @param {ExecutionContext} executionContext - The execution context for the current processing request.
+     * @param {IServiceProvider} services - The service provider to use for resolving services while handling the current request.
+     * @param {Logger} logger - The logger to use for logging.
+     * @returns {Promise<TResponse>} The response to the request.
+     */
     protected abstract handle(request: TRequest, executionContext: ExecutionContext, services: IServiceProvider, logger: Logger): Promise<TResponse>;
 
     /** @inheritdoc */

--- a/Source/events/EventContext.ts
+++ b/Source/events/EventContext.ts
@@ -15,12 +15,14 @@ export class EventContext {
      * @param {number} sequenceNumber - Sequence number in the event log the event belongs to.
      * @param {EventSourceId} eventSourceId - Unique identifier of the event source it originates from.
      * @param {DateTime} occurred - DateTime in UTC for when the event occurred.
-     * @param {ExecutionContext} executionContext - The execution context the event happened in.
+     * @param {ExecutionContext} committedExecutionContext - The execution context in which the event was committed to the event store.
+     * @param {ExecutionContext} currentExecutionContext - The execution context in which the event is currently being processed..
      */
     constructor(
         readonly sequenceNumber: number,
         readonly eventSourceId: EventSourceId,
         readonly occurred: DateTime,
-        readonly executionContext: ExecutionContext) {
+        readonly committedExecutionContext: ExecutionContext,
+        readonly currentExecutionContext: ExecutionContext) {
     }
 }

--- a/Source/projections/Internal/ProjectionProcessor.ts
+++ b/Source/projections/Internal/ProjectionProcessor.ts
@@ -9,7 +9,7 @@ import { IServiceProvider } from '@dolittle/sdk.dependencyinversion';
 import { EventContext, EventSourceId, EventType, IEventTypes } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { Internal, MissingEventInformation } from '@dolittle/sdk.events.processing';
-import { Artifacts, Guids } from '@dolittle/sdk.protobuf';
+import { Artifacts, ExecutionContexts, Guids } from '@dolittle/sdk.protobuf';
 import { Cancellation } from '@dolittle/sdk.resilience';
 import { IReverseCallClient, reactiveDuplex, ReverseCallClient } from '@dolittle/sdk.services';
 
@@ -166,6 +166,7 @@ export class ProjectionProcessor<T> extends Internal.EventProcessor<ProjectionId
             pbSequenceNumber,
             EventSourceId.from(pbEventSourceId),
             DateTime.fromJSDate(pbOccurred.toDate()),
+            ExecutionContexts.toSDK(pbExecutionContext),
             executionContext);
 
         if (!request.getCurrentstate() || !request.getCurrentstate()?.getState()) {

--- a/Source/services/ClientProcessor.ts
+++ b/Source/services/ClientProcessor.ts
@@ -146,18 +146,9 @@ export abstract class ClientProcessor<TIdentifier extends ConceptAs<Guid, string
         cancellation: Cancellation): IReverseCallClient<TRegisterResponse>;
 
     /**
-     * Handles the request from the Runtime.
-     * @param {TRequest} request - The request from the Runtime.
-     * @param {ExecutionContext} executionContext - The execution context.
-     * @param {IServiceProvider} services - The service provider to use for resolving services while handling the current request.
-     * @param {Logger} logger - The logger to use for logging.
-     */
-    protected abstract handle(request: TRequest, executionContext: ExecutionContext, services: IServiceProvider, logger: Logger): Promise<TResponse>;
-
-    /**
      * Wrapper around the handle() method to catch errors and set them to the response.
      * @param {TRequest} request - The request from the Runtime.
-     * @param {ExecutionContext} executionContext - The execution context.
+     * @param {ExecutionContext} executionContext - The execution context for the current processing request.
      * @param {IServiceProvider} services - The service provider to use for resolving services while handling the current request.
      * @param {Logger} logger - The logger to use for logging.
      */

--- a/Source/services/IReverseCallClient.ts
+++ b/Source/services/IReverseCallClient.ts
@@ -5,7 +5,7 @@ import { ExecutionContext } from '@dolittle/sdk.execution';
 import { PartialObserver, Subscribable, Unsubscribable } from 'rxjs';
 
 /**
- * Defines a reverse call client callback to handle a request comfing from the server to the client.
+ * Defines a reverse call client callback to handle a request coming from the server to the client.
  */
 export type ReverseCallCallback<TRequest, TResponse> = (request: TRequest, executionContext: ExecutionContext) => TResponse | Promise<TResponse>;
 


### PR DESCRIPTION
## Summary

Changed `EventContext` to contain both the current and the committed `ExecutionContext`, and fixed the event processors to include the committed event execution context.

### Changed

- `EventContext` now has `committedExecutionContex`+`currentExecutionContext` instead of `executionContext`, and is in line with .NET SDK.

### Fixed

- Committed execution context not passed along by event processors.
