### PR TITLE
Fix builders api

### DIFF
--- a/Samples/Tutorials/EventHorizon/Consumer/index.ts
+++ b/Samples/Tutorials/EventHorizon/Consumer/index.ts
@@ -20,12 +20,14 @@ import { DishPrepared } from './DishPrepared';
                         .toScope('808ddde4-c937-4f5c-9dc2-140580f6919e'));
             })
             .withEventHandlers(_ => _
-                .createEventHandler('6c3d358f-3ecc-4c92-a91e-5fc34cacf27e', _ =>
-                    _.inScope('808ddde4-c937-4f5c-9dc2-140580f6919e')
-                        .partitioned()
-                        .handle(DishPrepared, (event, context) => {
-                            client.logger.info(`Handled event ${JSON.stringify(event)} from public stream`);
-                         }))))
+                .create('6c3d358f-3ecc-4c92-a91e-5fc34cacf27e')
+                    .inScope('808ddde4-c937-4f5c-9dc2-140580f6919e')
+                    .partitioned()
+                    .handle(DishPrepared, (event, context) => {
+                        client.logger.info(`Handled event ${JSON.stringify(event)} from public stream`);
+                     })
+            )
+        )
         .connect(_ => _
             .withRuntimeOn('localhost', 50055)
         );

--- a/Samples/Tutorials/EventHorizon/Producer/index.ts
+++ b/Samples/Tutorials/EventHorizon/Producer/index.ts
@@ -15,12 +15,13 @@ import { DishPrepared } from './DishPrepared';
     const client = await DolittleClient
         .setup(_ => _
             .withFilters(_ => _
-                .createPublicFilter('2c087657-b318-40b1-ae92-a400de44e507', _ => _
+                .createPublic('2c087657-b318-40b1-ae92-a400de44e507')
                     .handle((event: any, context: EventContext) => {
                         client.logger.info(`Filtering event ${JSON.stringify(event)} to public stream`);
                         return new PartitionedFilterResult(true, 'Dolittle Tacos');
                     })
-                )))
+            )
+        )
         .connect();
 
     const preparedTaco = new DishPrepared('Bean Blaster Taco', 'Mr. Taco');

--- a/Samples/Tutorials/Projections/index.ts
+++ b/Samples/Tutorials/Projections/index.ts
@@ -14,15 +14,16 @@ import { DishPrepared } from './DishPrepared';
 (async () => {
     const client = await DolittleClient
         .setup(builder => builder
-            .withProjections(builder => {
-                builder.createProjection('0767bc04-bc03-40b8-a0be-5f6c6130f68b')
+            .withProjections(_ => _
+                .create('0767bc04-bc03-40b8-a0be-5f6c6130f68b')
                     .forReadModel(Chef)
                     .on(DishPrepared, _ => _.keyFromProperty('Chef'), (chef, event, projectionContext) => {
                         chef.name = event.Chef;
                         if (!chef.dishes.includes(event.Dish)) chef.dishes.push(event.Dish);
                         return chef;
-                    });
-            }))
+                    })
+            )
+        )
         .connect();
 
     const eventStore = client.eventStore.forTenant(TenantId.development);

--- a/Source/embeddings/Builders/EmbeddingsBuilder.ts
+++ b/Source/embeddings/Builders/EmbeddingsBuilder.ts
@@ -31,7 +31,7 @@ export class EmbeddingsBuilder extends IEmbeddingsBuilder {
     }
 
     /** @inheritdoc */
-    createEmbedding(embeddingId: string | EmbeddingId | Guid): IEmbeddingBuilder {
+    create(embeddingId: string | EmbeddingId | Guid): IEmbeddingBuilder {
         const id = EmbeddingId.from(embeddingId);
         const builder = new EmbeddingBuilder(id, this._modelBuilder);
         const identifier = new EmbeddingModelId(id);
@@ -40,7 +40,7 @@ export class EmbeddingsBuilder extends IEmbeddingsBuilder {
     }
 
     /** @inheritdoc */
-    registerEmbedding<T>(type: Constructor<T>): IEmbeddingsBuilder {
+    register<T>(type: Constructor<T>): IEmbeddingsBuilder {
         if (!isDecoratedEmbeddingType(type)) {
             this._buildResults.addFailure(`The embeddings class ${type.name} is not decorated as an embeddings`,`Add the @${embeddingDecorator.name} decorator to the class`);
             return this;

--- a/Source/embeddings/Builders/IEmbeddingsBuilder.ts
+++ b/Source/embeddings/Builders/IEmbeddingsBuilder.ts
@@ -14,14 +14,14 @@ export abstract class IEmbeddingsBuilder {
     /**
      * Start building an embedding.
      * @param {EmbeddingId | Guid | string} embeddingId - The unique identifier of the embedding.
-     * @returns {IEmbeddingBuilder} The builder for continuation.
+     * @returns {IEmbeddingBuilder} The builder for building the embeddings.
      */
-    abstract createEmbedding(embeddingId: EmbeddingId | Guid | string): IEmbeddingBuilder;
+    abstract create(embeddingId: EmbeddingId | Guid | string): IEmbeddingBuilder;
 
     /**
      * Register a type as an embedding.
      * @param type - The type to register as a embedding.
      * @returns {IEmbeddingsBuilder} The builder for continuation.
      */
-     abstract registerEmbedding<T>(type: Constructor<T>): IEmbeddingsBuilder;
+     abstract register<T>(type: Constructor<T>): IEmbeddingsBuilder;
 }

--- a/Source/events.filtering/EventFiltersBuilder.ts
+++ b/Source/events.filtering/EventFiltersBuilder.ts
@@ -8,9 +8,9 @@ import { IClientBuildResults, IModelBuilder } from '@dolittle/sdk.common';
 import { FilterId } from './FilterId';
 import { PublicEventFilterBuilder } from './PublicEventFilterBuilder';
 import { PrivateEventFilterBuilder } from './PrivateEventFilterBuilder';
-import { PublicEventFilterBuilderCallback } from './PublicEventFilterBuilderCallback';
-import { PrivateEventFilterBuilderCallback } from './PrivateEventFilterBuilderCallback';
 import { IEventFiltersBuilder } from './IEventFiltersBuilder';
+import { IPrivateEventFilterBuilder } from './IPrivateEventFilterBuilder';
+import { IPublicEventFilterBuilder } from './IPublicEventFilterBuilder';
 
 /**
  * Represents an implementation of {@link IEventFiltersBuilder}.
@@ -29,18 +29,14 @@ export class EventFiltersBuilder extends IEventFiltersBuilder {
     }
 
     /** @inheritdoc */
-    createPrivateFilter(filterId: string | FilterId | Guid, callback: PrivateEventFilterBuilderCallback): IEventFiltersBuilder {
+    createPrivate(filterId: string | FilterId | Guid): IPrivateEventFilterBuilder {
         const identifier = FilterId.from(filterId);
-        const builder = new PrivateEventFilterBuilder(identifier, this._modelBuilder);
-        callback(builder);
-        return this;
+        return new PrivateEventFilterBuilder(identifier, this._modelBuilder);
     }
 
     /** @inheritdoc */
-    createPublicFilter(filterId: string | FilterId | Guid, callback: PublicEventFilterBuilderCallback): IEventFiltersBuilder {
+    createPublic(filterId: string | FilterId | Guid): IPublicEventFilterBuilder {
         const identifier = FilterId.from(filterId);
-        const builder = new PublicEventFilterBuilder(identifier, this._modelBuilder);
-        callback(builder);
-        return this;
+        return new PublicEventFilterBuilder(identifier, this._modelBuilder);
     }
 }

--- a/Source/events.filtering/IEventFiltersBuilder.ts
+++ b/Source/events.filtering/IEventFiltersBuilder.ts
@@ -4,8 +4,8 @@
 import { Guid } from '@dolittle/rudiments';
 
 import { FilterId } from './FilterId';
-import { PrivateEventFilterBuilderCallback } from './PrivateEventFilterBuilderCallback';
-import { PublicEventFilterBuilderCallback } from './PublicEventFilterBuilderCallback';
+import { IPrivateEventFilterBuilder } from './IPrivateEventFilterBuilder';
+import { IPublicEventFilterBuilder } from './IPublicEventFilterBuilder';
 
 /**
  * Defines a builder for building event filters.
@@ -14,16 +14,14 @@ export abstract class IEventFiltersBuilder {
     /**
      * Start building for a private filter.
      * @param {FilterId | Guid | string} filterId - The identifier of the filter.
-     * @param {PrivateEventFilterBuilderCallback} callback - Callback for building the event filter.
-     * @returns {IEventFiltersBuilder} Continuation of the builder.
+     * @returns {IPrivateEventFilterBuilder} The builder for building the private filter.
      */
-    abstract createPrivateFilter(filterId: FilterId | Guid | string, callback: PrivateEventFilterBuilderCallback): IEventFiltersBuilder;
+    abstract createPrivate(filterId: FilterId | Guid | string): IPrivateEventFilterBuilder;
 
     /**
      * Start building for a public filter.
      * @param {FilterId | Guid | string} filterId - The identifier of the filter.
-     * @param {PublicEventFilterBuilderCallback} callback - Callback for building the event filter.
-     * @returns {IEventFiltersBuilder} Continuation of the builder.
+     * @returns {IPublicEventFilterBuilder} The builder for building the public filter.
      */
-    abstract createPublicFilter(filterId: FilterId | Guid | string, callback: PublicEventFilterBuilderCallback): IEventFiltersBuilder;
+    abstract createPublic(filterId: FilterId | Guid | string): IPublicEventFilterBuilder;
 }

--- a/Source/events.filtering/PrivateEventFilterBuilderCallback.ts
+++ b/Source/events.filtering/PrivateEventFilterBuilderCallback.ts
@@ -1,9 +1,0 @@
-// Copyright (c) Dolittle. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-import { IPrivateEventFilterBuilder } from './IPrivateEventFilterBuilder';
-
-/**
- * Defines the callback to use for creating private filters.
- */
-export type PrivateEventFilterBuilderCallback = (builder: IPrivateEventFilterBuilder) => void;

--- a/Source/events.filtering/PublicEventFilterBuilderCallback.ts
+++ b/Source/events.filtering/PublicEventFilterBuilderCallback.ts
@@ -1,9 +1,0 @@
-// Copyright (c) Dolittle. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-import { IPublicEventFilterBuilder } from './IPublicEventFilterBuilder';
-
-/**
- * Defines the callback to use for creating public filters.
- */
-export type PublicEventFilterBuilderCallback = (builder: IPublicEventFilterBuilder) => void;

--- a/Source/events.filtering/_exports.ts
+++ b/Source/events.filtering/_exports.ts
@@ -21,7 +21,5 @@ export { PartitionedEventFilterBuilder } from './PartitionedEventFilterBuilder';
 export { PartitionedFilterEventCallback } from './PartitionedFilterEventCallback';
 export { PartitionedFilterResult } from './PartitionedFilterResult';
 export { PrivateEventFilterBuilder } from './PrivateEventFilterBuilder';
-export { PrivateEventFilterBuilderCallback } from './PrivateEventFilterBuilderCallback';
 export { PublicEventFilterBuilder } from './PublicEventFilterBuilder';
-export { PublicEventFilterBuilderCallback } from './PublicEventFilterBuilderCallback';
 export { UnpartitionedEventFilterBuilder } from './UnpartitionedEventFilterBuilder';

--- a/Source/events.handling/Builders/EventHandlerBuilderCallback.ts
+++ b/Source/events.handling/Builders/EventHandlerBuilderCallback.ts
@@ -1,9 +1,0 @@
-// Copyright (c) Dolittle. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-import { EventHandlerBuilder } from './EventHandlerBuilder';
-
-/**
- * Defines the callback for building instances of {@link IEventHandler}.
- */
-export type EventHandlerBuilderCallback = (builder: EventHandlerBuilder) => void;

--- a/Source/events.handling/Builders/EventHandlersBuilder.ts
+++ b/Source/events.handling/Builders/EventHandlersBuilder.ts
@@ -8,11 +8,11 @@ import { IClientBuildResults, IModelBuilder } from '@dolittle/sdk.common';
 
 import { EventHandlerId } from '../EventHandlerId';
 import { EventHandlerBuilder } from './EventHandlerBuilder';
-import { EventHandlerBuilderCallback } from './EventHandlerBuilderCallback';
 import { EventHandlerClassBuilder } from './EventHandlerClassBuilder';
 import { eventHandler as eventHandlerDecorator, isDecoratedEventHandlerType, getDecoratedEventHandlerType } from './eventHandlerDecorator';
 import { IEventHandlersBuilder } from './IEventHandlersBuilder';
 import { EventHandlerModelId } from '../EventHandlerModelId';
+import { IEventHandlerBuilder } from './IEventHandlerBuilder';
 
 /**
  * Represents an implementation of {@link IEventHandlersBuilder}.
@@ -31,17 +31,15 @@ export class EventHandlersBuilder extends IEventHandlersBuilder {
     }
 
     /** @inheritdoc */
-    createEventHandler(eventHandlerId: string | EventHandlerId | Guid, callback: EventHandlerBuilderCallback): IEventHandlersBuilder {
+    create(eventHandlerId: string | EventHandlerId | Guid): IEventHandlerBuilder {
         const identifier = EventHandlerId.from(eventHandlerId);
-        const builder = new EventHandlerBuilder(identifier, this._modelBuilder);
-        callback(builder);
-        return this;
+        return new EventHandlerBuilder(identifier, this._modelBuilder);
     }
 
     /** @inheritdoc */
-    registerEventHandler<T = any>(type: Constructor<T>): IEventHandlersBuilder;
-    registerEventHandler<T = any>(instance: T): IEventHandlersBuilder;
-    registerEventHandler<T = any>(typeOrInstance: Constructor<T> | T): EventHandlersBuilder {
+    register<T = any>(type: Constructor<T>): IEventHandlersBuilder;
+    register<T = any>(instance: T): IEventHandlersBuilder;
+    register<T = any>(typeOrInstance: Constructor<T> | T): IEventHandlersBuilder {
         const type = typeOrInstance instanceof Function ? typeOrInstance : Object.getPrototypeOf(typeOrInstance).constructor;
         const instance = typeOrInstance instanceof Function ? undefined : typeOrInstance;
         if (type === undefined) {

--- a/Source/events.handling/Builders/IEventHandlersBuilder.ts
+++ b/Source/events.handling/Builders/IEventHandlersBuilder.ts
@@ -5,7 +5,7 @@ import { Guid } from '@dolittle/rudiments';
 import { Constructor } from '@dolittle/types';
 
 import { EventHandlerId } from '../EventHandlerId';
-import { EventHandlerBuilderCallback } from './EventHandlerBuilderCallback';
+import { IEventHandlerBuilder } from './IEventHandlerBuilder';
 
 /**
  * Defines a builder that can build event handlers.
@@ -14,22 +14,21 @@ export abstract class IEventHandlersBuilder {
     /**
      * Start building an event handler.
      * @param {EventHandlerId | Guid | string} eventHandlerId - The unique identifier of the event handler.
-     * @param {EventHandlerBuilderCallback} callback - Callback for building out the event handler.
-     * @returns {IEventHandlersBuilder} The builder for continuation.
+     * @returns {IEventHandlerBuilder} The builder for building the event handler.
      */
-    abstract createEventHandler(eventHandlerId: EventHandlerId | Guid | string, callback: EventHandlerBuilderCallback): IEventHandlersBuilder;
+    abstract create(eventHandlerId: EventHandlerId | Guid | string): IEventHandlerBuilder;
 
     /**
      * Register a type as an event handler.
      * @param type - The type to register as an event handler.
      * @returns {IEventHandlersBuilder} The builder for continuation.
      */
-    abstract registerEventHandler<T = any>(type: Constructor<T>): IEventHandlersBuilder;
+    abstract register<T = any>(type: Constructor<T>): IEventHandlersBuilder;
 
     /**
      * Register an instance as an event handler.
      * @param instance - The instance to register as an event handler.
      * @returns {IEventHandlersBuilder} The builder for continuation.
      */
-    abstract registerEventHandler<T = any>(instance: T): IEventHandlersBuilder;
+    abstract register<T = any>(instance: T): IEventHandlersBuilder;
 }

--- a/Source/events.handling/Builders/_exports.ts
+++ b/Source/events.handling/Builders/_exports.ts
@@ -3,7 +3,6 @@
 
 export { CouldNotCreateInstanceOfEventHandler } from './CouldNotCreateInstanceOfEventHandler';
 export { EventHandlerBuilder } from './EventHandlerBuilder';
-export { EventHandlerBuilderCallback } from './EventHandlerBuilderCallback';
 export { EventHandlerClassBuilder } from './EventHandlerClassBuilder';
 export { EventHandlerDecoratedType } from './EventHandlerDecoratedType';
 export { eventHandler, isDecoratedEventHandlerType, getDecoratedEventHandlerType } from './eventHandlerDecorator';

--- a/Source/events.handling/index.ts
+++ b/Source/events.handling/index.ts
@@ -6,7 +6,6 @@ export * from './_exports';
 export {
     CouldNotCreateInstanceOfEventHandler,
     EventHandlerBuilder,
-    EventHandlerBuilderCallback,
     EventHandlerClassBuilder,
     EventHandlerDecoratedType,
     eventHandler,

--- a/Source/projections/Builders/IProjectionsBuilder.ts
+++ b/Source/projections/Builders/IProjectionsBuilder.ts
@@ -14,13 +14,14 @@ export abstract class IProjectionsBuilder {
     /**
      * Start building a projection.
      * @param {ProjectionId | Guid | string} projectionId - The unique identifier of the projection.
-     * @returns {IProjectionsBuilder} The projections builder for continuation.
+     * @returns {IProjectionBuilder} The builder for building the projection.
      */
-    abstract createProjection(projectionId: ProjectionId | Guid | string): IProjectionBuilder;
+    abstract create(projectionId: ProjectionId | Guid | string): IProjectionBuilder;
 
     /**
      * Register a type as a projection.
      * @param type - The type to register as a projection.
+     * @returns {IProjectionsBuilder} The projections builder for continuation.
      */
-    abstract registerProjection<T = any>(type: Constructor<T>): IProjectionsBuilder;
+    abstract register<T = any>(type: Constructor<T>): IProjectionsBuilder;
 }

--- a/Source/projections/Builders/ProjectionsBuilder.ts
+++ b/Source/projections/Builders/ProjectionsBuilder.ts
@@ -31,13 +31,13 @@ export class ProjectionsBuilder extends IProjectionsBuilder {
     }
 
     /** @inheritdoc */
-    createProjection(projectionId: string | ProjectionId | Guid): IProjectionBuilder {
+    create(projectionId: string | ProjectionId | Guid): IProjectionBuilder {
         const identifier = ProjectionId.from(projectionId);
         return new ProjectionBuilder(identifier, this._modelBuilder);
     }
 
     /** @inheritdoc */
-    registerProjection<T = any>(type: Constructor<T>): IProjectionsBuilder {
+    register<T = any>(type: Constructor<T>): IProjectionsBuilder {
         if (!isDecoratedProjectionType(type)) {
             this._buildResults.addFailure(`The projection class ${type.name} is not decorated as an projection`,`Add the @${projectionDecorator.name} decorator to the class`);
             return this;

--- a/Source/sdk/Builders/SetupBuilder.ts
+++ b/Source/sdk/Builders/SetupBuilder.ts
@@ -152,15 +152,15 @@ export class SetupBuilder extends ISetupBuilder {
             }
 
             if (isDecoratedEventHandlerType(type)) {
-                this._eventHandlersBuilder.registerEventHandler(type);
+                this._eventHandlersBuilder.register(type);
             }
 
             if (isDecoratedProjectionType(type)) {
-                this._projectionsBuilder.registerProjection(type);
+                this._projectionsBuilder.register(type);
             }
 
             if (isDecoratedEmbeddingType(type)) {
-                this._embeddingsBuilder.registerEmbedding(type);
+                this._embeddingsBuilder.register(type);
             }
         });
     }


### PR DESCRIPTION
## Summary

Make builders APIs all the same. Renamed all to be `register/create`, and for all to return the individual builders instead of accepting a callback to configure them.

### Changed

- Builders methods are now called just `create(id)` or `register(type)` for all kinds.
- `create(id)` methods return the individual kind builder instead of accepting a callback (some already did this).
