### PR TITLE
Bind IAggregateOg<> in the ServiceProvider

### DIFF
--- a/Source/aggregates/Builders/AggregateRootsModelBuilder.ts
+++ b/Source/aggregates/Builders/AggregateRootsModelBuilder.ts
@@ -2,10 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { IModel } from '@dolittle/sdk.common';
+import { IServiceProviderBuilder } from '@dolittle/sdk.dependencyinversion';
 
 import { AggregateRootTypes } from '../AggregateRootTypes';
-import { IAggregateRootTypes } from '../IAggregateRootTypes';
 import { isAggregateRootModelId } from '../AggregateRootModelId';
+import { IAggregateRootTypes } from '../IAggregateRootTypes';
+import { IAggregateOf } from '../IAggregateOf';
+import { IAggregates } from './IAggregates';
 
 /**
  * Represents a builder that can build {@link IAggregateRootTypes} from an {@link IModel}.
@@ -14,9 +17,11 @@ export class AggregateRootsModelBuilder {
     /**
      * Initialises a new instance of the {@link AggregateRootsModelBuilder} class.
      * @param {IModel} _model - The built application model.
+     * @param {IServiceProviderBuilder} _bindings - For registering the bindings for {@link IAggregateOf} types.
      */
     constructor(
         private readonly _model: IModel,
+        private readonly _bindings: IServiceProviderBuilder,
     ) {}
 
     /**
@@ -28,6 +33,10 @@ export class AggregateRootsModelBuilder {
         const aggregateRootTypes = new AggregateRootTypes();
         for (const { identifier, type } of bindings) {
             aggregateRootTypes.associate(type, identifier.aggregateRootType);
+
+            this._bindings.addTenantServices(binder => {
+                binder.bind(`IAggregateOf<${type.name}>`).toFactory(services => services.get(IAggregates).of(type));
+            });
         }
         return aggregateRootTypes;
     }

--- a/Source/sdk/Builders/SetupBuilder.ts
+++ b/Source/sdk/Builders/SetupBuilder.ts
@@ -117,7 +117,7 @@ export class SetupBuilder extends ISetupBuilder {
         const model = this._modelBuilder.build(this._buildResults);
 
         const eventTypes = new EventTypesModelBuilder(model).build();
-        const aggregateRootTypes = new AggregateRootsModelBuilder(model).build();
+        const aggregateRootTypes = new AggregateRootsModelBuilder(model, bindings).build();
 
         const filters = new EventFiltersModelBuilder(model, this._buildResults, eventTypes).build();
         const eventHandlers = new EventHandlersModelBuilder(model, this._buildResults, eventTypes, bindings).build();


### PR DESCRIPTION
## Summary

Bind the `IAggregateOf<...>` into the DI container for the registered aggregate root types. Unfortunately the generics disappear when compiled to JavaScript, so the bindings are just with string identifiers - so you need to do something like `services.get('IAggregateOf<Kitchen>') as IAggregateOf<Kitchen>`.