### PR TITLE
Projections GetAll batching

### DIFF
--- a/Source/aggregates/package.json
+++ b/Source/aggregates/package.json
@@ -44,15 +44,15 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.events": "21.0.0",
         "@dolittle/sdk.execution": "21.0.0",
         "@dolittle/sdk.protobuf": "21.0.0",
         "@dolittle/sdk.resilience": "21.0.0",
         "@dolittle/sdk.services": "21.0.0",
-        "@dolittle/types": "6.0.0-gimli.0",
+        "@dolittle/types": "6.0.0",
         "winston": "3.3.2"
     },
     "devDependencies": {}

--- a/Source/artifacts/package.json
+++ b/Source/artifacts/package.json
@@ -47,7 +47,7 @@
         "@dolittle/concepts": "6.0.0-gimli.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
         "@dolittle/types": "6.0.0-gimli.0",
-        "@dolittle/runtime.contracts": "6.4.0"
+        "@dolittle/runtime.contracts": "6.5.0"
     },
     "devDependencies": {
         "@types/is-natural-number": "^4.0.0"

--- a/Source/artifacts/package.json
+++ b/Source/artifacts/package.json
@@ -44,9 +44,9 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
-        "@dolittle/types": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
+        "@dolittle/rudiments": "6.0.0",
+        "@dolittle/types": "6.0.0",
         "@dolittle/runtime.contracts": "6.5.0"
     },
     "devDependencies": {

--- a/Source/common/package.json
+++ b/Source/common/package.json
@@ -44,9 +44,9 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.execution": "21.0.0",
-        "@dolittle/types": "6.0.0-gimli.0",
+        "@dolittle/types": "6.0.0",
         "winston": "3.3.2"
     },
     "devDependencies": {}

--- a/Source/dependencyInversion/package.json
+++ b/Source/dependencyInversion/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@dolittle/sdk.common": "21.0.0",
         "@dolittle/sdk.execution": "21.0.0",
-        "@dolittle/types": "6.0.0-gimli.0",
+        "@dolittle/types": "6.0.0",
         "inversify": "6.0.1",
         "winston": "3.3.2"
     },

--- a/Source/embeddings/package.json
+++ b/Source/embeddings/package.json
@@ -44,9 +44,9 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
         "@dolittle/contracts": "6.5.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.common": "21.0.0",
@@ -58,7 +58,7 @@
         "@dolittle/sdk.protobuf": "21.0.0",
         "@dolittle/sdk.resilience": "21.0.0",
         "@dolittle/sdk.services": "21.0.0",
-        "@dolittle/types": "6.0.0-gimli.0",
+        "@dolittle/types": "6.0.0",
         "luxon": "1.24.1",
         "@types/luxon": "1.24.1"
     },

--- a/Source/embeddings/package.json
+++ b/Source/embeddings/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/contracts": "6.4.0",
+        "@dolittle/contracts": "6.5.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
-        "@dolittle/runtime.contracts": "6.4.0",
+        "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.common": "21.0.0",
         "@dolittle/sdk.dependencyinversion": "21.0.0",

--- a/Source/eventHorizon/package.json
+++ b/Source/eventHorizon/package.json
@@ -44,8 +44,8 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.events": "21.0.0",
         "@dolittle/sdk.execution": "21.0.0",

--- a/Source/eventHorizon/package.json
+++ b/Source/eventHorizon/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@dolittle/concepts": "6.0.0-gimli.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
-        "@dolittle/runtime.contracts": "6.4.0",
+        "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.events": "21.0.0",
         "@dolittle/sdk.execution": "21.0.0",
         "@dolittle/sdk.protobuf": "21.0.0",

--- a/Source/events.filtering/package.json
+++ b/Source/events.filtering/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/contracts": "6.4.0",
+        "@dolittle/contracts": "6.5.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
-        "@dolittle/runtime.contracts": "6.4.0",
+        "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.common": "21.0.0",
         "@dolittle/sdk.dependencyinversion": "21.0.0",
         "@dolittle/sdk.events": "21.0.0",

--- a/Source/events.filtering/package.json
+++ b/Source/events.filtering/package.json
@@ -44,9 +44,9 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
         "@dolittle/contracts": "6.5.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.common": "21.0.0",
         "@dolittle/sdk.dependencyinversion": "21.0.0",

--- a/Source/events.handling/package.json
+++ b/Source/events.handling/package.json
@@ -44,9 +44,9 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
         "@dolittle/contracts": "6.5.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.common": "21.0.0",
@@ -57,7 +57,7 @@
         "@dolittle/sdk.protobuf": "21.0.0",
         "@dolittle/sdk.resilience": "21.0.0",
         "@dolittle/sdk.services": "21.0.0",
-        "@dolittle/types": "6.0.0-gimli.0",
+        "@dolittle/types": "6.0.0",
         "rxjs": "6.6.0",
         "luxon": "1.24.1",
         "winston": "3.3.2"

--- a/Source/events.handling/package.json
+++ b/Source/events.handling/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/contracts": "6.4.0",
+        "@dolittle/contracts": "6.5.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
-        "@dolittle/runtime.contracts": "6.4.0",
+        "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.common": "21.0.0",
         "@dolittle/sdk.dependencyinversion": "21.0.0",

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/contracts": "6.4.0",
+        "@dolittle/contracts": "6.5.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
-        "@dolittle/runtime.contracts": "6.4.0",
+        "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.common": "21.0.0",
         "@dolittle/sdk.dependencyinversion": "21.0.0",
         "@dolittle/sdk.execution": "21.0.0",

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -53,6 +53,7 @@
         "@dolittle/sdk.execution": "21.0.0",
         "@dolittle/sdk.resilience": "21.0.0",
         "@dolittle/sdk.services": "21.0.0",
+        "@grpc/grpc-js": "1.2.12",
         "rxjs": "6.6.0",
         "winston": "3.3.2"
     }

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -44,9 +44,9 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
         "@dolittle/contracts": "6.5.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.common": "21.0.0",
         "@dolittle/sdk.dependencyinversion": "21.0.0",

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -44,16 +44,16 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
         "@dolittle/contracts": "6.5.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.execution": "21.0.0",
         "@dolittle/sdk.protobuf": "21.0.0",
         "@dolittle/sdk.resilience": "21.0.0",
         "@dolittle/sdk.services": "21.0.0",
-        "@dolittle/types": "6.0.0-gimli.0",
+        "@dolittle/types": "6.0.0",
         "luxon": "1.24.1",
         "rxjs": "6.6.0",
         "winston": "3.3.2"

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/contracts": "6.4.0",
+        "@dolittle/contracts": "6.5.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
-        "@dolittle/runtime.contracts": "6.4.0",
+        "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.execution": "21.0.0",
         "@dolittle/sdk.protobuf": "21.0.0",

--- a/Source/execution/package.json
+++ b/Source/execution/package.json
@@ -44,7 +44,7 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0"
+        "@dolittle/concepts": "6.0.0",
+        "@dolittle/rudiments": "6.0.0"
     }
 }

--- a/Source/extensions.express/package.json
+++ b/Source/extensions.express/package.json
@@ -45,7 +45,7 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk": "21.0.0",
         "@dolittle/sdk.aggregates": "21.0.0",
         "@dolittle/sdk.dependencyinversion": "21.0.0",

--- a/Source/projections/Store/ProjectionStore.ts
+++ b/Source/projections/Store/ProjectionStore.ts
@@ -5,6 +5,7 @@ import { map, reduce } from 'rxjs/operators';
 import { Logger } from 'winston';
 import { Guid } from '@dolittle/rudiments';
 
+import { ComplexValueMap } from '@dolittle/sdk.artifacts';
 import { ScopeId } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { ExecutionContexts, Failures, Guids } from '@dolittle/sdk.protobuf';
@@ -111,7 +112,7 @@ export class ProjectionStore extends IProjectionStore {
                     }
 
                     return all;
-                }, new Map<Key, CurrentState<TProjection>>())
+                }, new ComplexValueMap<Key, CurrentState<TProjection>, [string]>(Key, key => [key.value], 1))
             ).toPromise();
     }
 

--- a/Source/projections/Store/ProjectionStore.ts
+++ b/Source/projections/Store/ProjectionStore.ts
@@ -25,6 +25,7 @@ import { FailedToGetProjection } from './FailedToGetProjection';
 import { FailedToGetProjectionState } from './FailedToGetProjectionState';
 import { IProjectionReadModelTypes } from './IProjectionReadModelTypes';
 import { IProjectionStore } from './IProjectionStore';
+import { ReceivedDuplicateProjectionKeys } from './ReceivedDuplicateProjectionKeys';
 
 /**
  * Represents an implementation of {@link IProjectionStore}.
@@ -108,6 +109,10 @@ export class ProjectionStore extends IProjectionStore {
                     this._logger.debug(`Received batch ${index} with ${batch.size} states from projection ${projection} in scope ${scope}`);
 
                     for (const [key, state] of batch) {
+                        if (all.has(key)) {
+                            throw new ReceivedDuplicateProjectionKeys(projection, scope, key);
+                        }
+
                         all.set(key, state);
                     }
 

--- a/Source/projections/Store/ProjectionStore.ts
+++ b/Source/projections/Store/ProjectionStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { map } from 'rxjs/operators';
+import { map, reduce } from 'rxjs/operators';
 import { Logger } from 'winston';
 import { Guid } from '@dolittle/rudiments';
 
@@ -9,7 +9,7 @@ import { ScopeId } from '@dolittle/sdk.events';
 import { ExecutionContext } from '@dolittle/sdk.execution';
 import { ExecutionContexts, Failures, Guids } from '@dolittle/sdk.protobuf';
 import { Cancellation } from '@dolittle/sdk.resilience';
-import { reactiveUnary } from '@dolittle/sdk.services';
+import { reactiveServerStream, reactiveUnary } from '@dolittle/sdk.services';
 import { Constructor } from '@dolittle/types';
 
 import { ProjectionsClient } from '@dolittle/runtime.contracts/Projections/Store_grpc_pb';
@@ -97,11 +97,22 @@ export class ProjectionStore extends IProjectionStore {
         request.setProjectionid(Guids.toProtobuf(projection.value));
         request.setScopeid(Guids.toProtobuf(scope.value));
 
-        return reactiveUnary(this._projectionsClient, this._projectionsClient.getAll, request, cancellation)
-            .pipe(map(response => {
-                this.throwIfHasFailure(response, projection, scope);
-                return this._converter.convertAll<TProjection>(type, response.getStatesList());
-            })).toPromise();
+        return reactiveServerStream(this._projectionsClient, this._projectionsClient.getAllInBatches, request, cancellation)
+            .pipe(
+                map(response => {
+                    this.throwIfHasFailure(response, projection, scope);
+                    return this._converter.convertAll<TProjection>(type, response.getStatesList());
+                }),
+                reduce((all, batch, index) => {
+                    this._logger.debug(`Received batch ${index} with ${batch.size} states from projection ${projection} in scope ${scope}`);
+
+                    for (const [key, state] of batch) {
+                        all.set(key, state);
+                    }
+
+                    return all;
+                }, new Map<Key, CurrentState<TProjection>>())
+            ).toPromise();
     }
 
     private getKeyFrom<TProjection>(typeOrKey: Constructor<TProjection> | Key | any, keyOrProjection: Key | any | ProjectionId | Guid | string): Key {

--- a/Source/projections/Store/ReceivedDuplicateProjectionKeys.ts
+++ b/Source/projections/Store/ReceivedDuplicateProjectionKeys.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Exception } from '@dolittle/rudiments';
+import { ScopeId } from '@dolittle/sdk.events';
+
+import { Key } from '../Key';
+import { ProjectionId } from '../ProjectionId';
+
+/**
+ * The exception that gets thrown when multiple projection states with the same key is received from the Runtime when getting all states.
+ */
+export class ReceivedDuplicateProjectionKeys extends Exception {
+    /**
+     * Initialises a new instance of the {@link ReceivedDuplicateProjectionKeys} class.
+     * @param {ProjectionId} projection - The projection identifier.
+     * @param {ScopeId} scope - The scope of the projection.
+     * @param {Key} key - The key that was duplicated.
+     */
+    constructor(projection: ProjectionId, scope: ScopeId, key: Key) {
+        super(`Received multiple states from the Runtime with the key ${key} for projection ${projection} in scope ${scope} when getting all.`);
+    }
+}

--- a/Source/projections/Store/_exports.ts
+++ b/Source/projections/Store/_exports.ts
@@ -12,5 +12,6 @@ export { IProjectionReadModelTypes } from './IProjectionReadModelTypes';
 export { IProjectionStore } from './IProjectionStore';
 export { ProjectionReadModelTypes } from './ProjectionReadModelTypes';
 export { ProjectionStore } from './ProjectionStore';
+export { ReceivedDuplicateProjectionKeys } from './ReceivedDuplicateProjectionKeys';
 export { ScopedProjectionId } from './ScopedProjectionId';
 export { TypeIsNotAProjection } from './TypeIsNotAProjection';

--- a/Source/projections/Store/for_ProjectionStore/given.ts
+++ b/Source/projections/Store/for_ProjectionStore/given.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ClientReadableStream } from '@grpc/grpc-js';
+import { EventEmitter } from 'stream';
+import { stubInterface } from 'ts-sinon';
+import { Logger } from 'winston';
+
+import { Claims, CorrelationId, Environment, ExecutionContext, MicroserviceId, TenantId, Version } from '@dolittle/sdk.execution';
+
+import { ProjectionsClient } from '@dolittle/runtime.contracts/Projections/Store_grpc_pb';
+import { GetAllResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
+
+import { IProjectionReadModelTypes } from '../IProjectionReadModelTypes';
+import { ProjectionReadModelTypes } from '../ProjectionReadModelTypes';
+
+export default {
+    get an_execution_context(): ExecutionContext {
+        return new ExecutionContext(
+            MicroserviceId.notApplicable,
+            TenantId.unknown,
+            Version.notSet,
+            Environment.undetermined,
+            CorrelationId.system,
+            Claims.empty,
+        );
+    },
+
+    get a_logger(): Logger {
+        return stubInterface<Logger>();
+    },
+
+    get empty_read_model_types(): IProjectionReadModelTypes {
+        return new ProjectionReadModelTypes();
+    },
+
+    get projections_client_and_get_all_stream(): [ProjectionsClient, ClientReadableStream<GetAllResponse>] {
+        const getAllStream = new EventEmitter() as ClientReadableStream<GetAllResponse>;
+
+        const projectionsClient = stubInterface<ProjectionsClient>({
+            getAllInBatches: getAllStream,
+        });
+
+        return [projectionsClient, getAllStream];
+    },
+};

--- a/Source/projections/Store/for_ProjectionStore/when_getting_all/by_ids/and_it_returns_a_failure.ts
+++ b/Source/projections/Store/for_ProjectionStore/when_getting_all/by_ids/and_it_returns_a_failure.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+
+import { Cancellation } from '@dolittle/sdk.resilience';
+
+import { Failure } from '@dolittle/contracts/Protobuf/Failure_pb';
+import { GetAllResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
+
+import given from '../../given';
+import { ProjectionStore } from '../../../ProjectionStore';
+
+describeThis(__filename, () => {
+    const [projections_client, server_stream] = given.projections_client_and_get_all_stream;
+
+    const projection_store = new ProjectionStore(
+        projections_client,
+        given.an_execution_context,
+        given.empty_read_model_types,
+        given.a_logger);
+
+    const result = projection_store.getAll('ab3be0d3-e550-4ac0-8646-87f376d3d1b0', '6f428480-4cb6-4454-b52d-dd453f6e8a98', Cancellation.default);
+    result.catch();
+
+    const failure = new Failure();
+    const response = new GetAllResponse();
+    response.setFailure(failure);
+    server_stream.emit('data', response);
+    server_stream.emit('end');
+
+    it('should throw an exception', () => result.should.eventually.be.rejected);
+});

--- a/Source/projections/Store/for_ProjectionStore/when_getting_all/by_ids/and_it_returns_multiple_batches.ts
+++ b/Source/projections/Store/for_ProjectionStore/when_getting_all/by_ids/and_it_returns_multiple_batches.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+
+import { Cancellation } from '@dolittle/sdk.resilience';
+
+import { GetAllResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
+import { ProjectionCurrentState } from '@dolittle/runtime.contracts/Projections/State_pb';
+
+import given from '../../given';
+import { Key } from '../../../../Key';
+import { ProjectionStore } from '../../../ProjectionStore';
+import { CurrentState } from '../../../CurrentState';
+import { CurrentStateType } from '../../../CurrentStateType';
+
+describeThis(__filename, () => {
+    const [projections_client, server_stream] = given.projections_client_and_get_all_stream;
+
+    const projection_store = new ProjectionStore(
+        projections_client,
+        given.an_execution_context,
+        given.empty_read_model_types,
+        given.a_logger);
+
+    const result = projection_store.getAll('ab3be0d3-e550-4ac0-8646-87f376d3d1b0', '6f428480-4cb6-4454-b52d-dd453f6e8a98', Cancellation.default);
+    const keys = result.then(_ => Array.from(_.keys()));
+    const entries = result.then(_ => Array.from(_.entries()));
+
+    const first_state = new ProjectionCurrentState();
+    first_state.setKey('first key');
+    first_state.setState('{ "first": "state" }');
+
+    const second_state = new ProjectionCurrentState();
+    second_state.setKey('second key');
+    second_state.setState('{ "second": "state" }');
+
+    const third_state = new ProjectionCurrentState();
+    third_state.setKey('third key');
+    third_state.setState('{ "third": "state" }');
+
+    const first_batch = new GetAllResponse();
+    first_batch.setStatesList([first_state, second_state]);
+
+    const second_batch = new GetAllResponse();
+    second_batch.setStatesList([third_state]);
+
+    server_stream.emit('data', first_batch);
+    server_stream.emit('data', second_batch);
+    server_stream.emit('end');
+
+    it('should return all 3 keys', () => keys.should.eventually.have.deep.members([
+        Key.from('first key'),
+        Key.from('second key'),
+        Key.from('third key'),
+    ]));
+    it('should return the first state for the first key', () => entries.should.eventually.deep.include([
+        Key.from('first key'),
+        new CurrentState(CurrentStateType.CreatedFromInitialState, { first: 'state' }, Key.from('first key')),
+    ]));
+    it('should return the second state for the second key', () => entries.should.eventually.deep.include([
+        Key.from('second key'),
+        new CurrentState(CurrentStateType.CreatedFromInitialState, { second: 'state' }, Key.from('second key')),
+    ]));
+    it('should return the third state for the third key', () => entries.should.eventually.deep.include([
+        Key.from('third key'),
+        new CurrentState(CurrentStateType.CreatedFromInitialState, { third: 'state' }, Key.from('third key')),
+    ]));
+});

--- a/Source/projections/Store/for_ProjectionStore/when_getting_all/by_ids/and_it_returns_the_same_key_multple_times.ts
+++ b/Source/projections/Store/for_ProjectionStore/when_getting_all/by_ids/and_it_returns_the_same_key_multple_times.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+
+import { Cancellation } from '@dolittle/sdk.resilience';
+
+import { GetAllResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
+import { ProjectionCurrentState } from '@dolittle/runtime.contracts/Projections/State_pb';
+
+import given from '../../given';
+import { Key } from '../../../../Key';
+import { ProjectionStore } from '../../../ProjectionStore';
+import { CurrentState } from '../../../CurrentState';
+import { CurrentStateType } from '../../../CurrentStateType';
+
+describeThis(__filename, () => {
+    const [projections_client, server_stream] = given.projections_client_and_get_all_stream;
+
+    const projection_store = new ProjectionStore(
+        projections_client,
+        given.an_execution_context,
+        given.empty_read_model_types,
+        given.a_logger);
+
+    const result = projection_store.getAll('ab3be0d3-e550-4ac0-8646-87f376d3d1b0', '6f428480-4cb6-4454-b52d-dd453f6e8a98', Cancellation.default);
+    const keys = result.then(_ => Array.from(_.keys()));
+    const entries = result.then(_ => Array.from(_.entries()));
+
+    const first_state = new ProjectionCurrentState();
+    first_state.setKey('first key');
+    first_state.setState('{ "first": "state" }');
+
+    const second_state = new ProjectionCurrentState();
+    second_state.setKey('first key');
+    second_state.setState('{ "second": "state" }');
+
+    const first_batch = new GetAllResponse();
+    first_batch.setStatesList([first_state, second_state]);
+
+    server_stream.emit('data', first_batch);
+    server_stream.emit('end');
+
+    it('should only have one key', () => keys.should.eventually.have.lengthOf(1));
+    it('should overwrite the state of the key', () => entries.should.eventually.deep.include([
+        Key.from('first key'),
+        new CurrentState(CurrentStateType.CreatedFromInitialState, { second: 'state' }, Key.from('first key')),
+    ]));
+});

--- a/Source/projections/index.ts
+++ b/Source/projections/index.ts
@@ -39,6 +39,7 @@ export {
     IProjectionStore,
     ProjectionReadModelTypes,
     ProjectionStore,
+    ReceivedDuplicateProjectionKeys,
     ScopedProjectionId,
     TypeIsNotAProjection,
 } from './Store/_exports';

--- a/Source/projections/package.json
+++ b/Source/projections/package.json
@@ -44,9 +44,9 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
         "@dolittle/contracts": "6.5.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.common": "21.0.0",
@@ -57,7 +57,7 @@
         "@dolittle/sdk.protobuf": "21.0.0",
         "@dolittle/sdk.resilience": "21.0.0",
         "@dolittle/sdk.services": "21.0.0",
-        "@dolittle/types": "6.0.0-gimli.0",
+        "@dolittle/types": "6.0.0",
         "luxon": "1.24.1",
         "@types/luxon": "1.24.1"
     },

--- a/Source/projections/package.json
+++ b/Source/projections/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/contracts": "6.4.0",
+        "@dolittle/contracts": "6.5.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
-        "@dolittle/runtime.contracts": "6.4.0",
+        "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.common": "21.0.0",
         "@dolittle/sdk.dependencyinversion": "21.0.0",

--- a/Source/protobuf/package.json
+++ b/Source/protobuf/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/contracts": "6.4.0",
+        "@dolittle/contracts": "6.5.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.execution": "21.0.0"

--- a/Source/protobuf/package.json
+++ b/Source/protobuf/package.json
@@ -45,9 +45,9 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
         "@dolittle/contracts": "6.5.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.execution": "21.0.0"
     }

--- a/Source/resources/package.json
+++ b/Source/resources/package.json
@@ -44,9 +44,9 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
         "@dolittle/contracts": "6.5.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.execution": "21.0.0",
         "@dolittle/sdk.protobuf": "21.0.0",

--- a/Source/resources/package.json
+++ b/Source/resources/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/contracts": "6.4.0",
+        "@dolittle/contracts": "6.5.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
-        "@dolittle/runtime.contracts": "6.4.0",
+        "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.execution": "21.0.0",
         "@dolittle/sdk.protobuf": "21.0.0",
         "@dolittle/sdk.resilience": "21.0.0",

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -45,7 +45,7 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/runtime.contracts": "6.4.0",
+        "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.aggregates": "21.0.0",
         "@dolittle/sdk.artifacts": "21.0.0",
         "@dolittle/sdk.common": "21.0.0",

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -63,7 +63,7 @@
         "@dolittle/sdk.resources": "21.0.0",
         "@dolittle/sdk.services": "21.0.0",
         "@dolittle/sdk.tenancy": "21.0.0",
-        "@dolittle/types": "6.0.0-gimli.0",
+        "@dolittle/types": "6.0.0",
         "@grpc/grpc-js": "1.2.12",
         "rxjs": "6.6.0",
         "winston": "3.3.2"

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -64,6 +64,7 @@
         "@dolittle/sdk.services": "21.0.0",
         "@dolittle/sdk.tenancy": "21.0.0",
         "@dolittle/types": "6.0.0-gimli.0",
+        "@grpc/grpc-js": "1.2.12",
         "rxjs": "6.6.0",
         "winston": "3.3.2"
     }

--- a/Source/services/GrpcMethods.ts
+++ b/Source/services/GrpcMethods.ts
@@ -16,9 +16,9 @@ export type ClientStreamMethod<TRequest, TResponse> = (metadata: grpc.Metadata, 
 /**
  * Represents a server streaming gRPC method.
  */
-export type ServerStreamMethod<TArgument, TResponse> = (argument: TArgument, metadata?: grpc.Metadata | null, options?: grpc.CallOptions | null) => grpc.ClientReadableStream<TResponse>;
+export type ServerStreamMethod<TArgument, TResponse> = (argument: TArgument, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>) => grpc.ClientReadableStream<TResponse>;
 
 /**
  * Represents a duplex streaming gRPC method.
  */
-export type DuplexMethod<TRequest, TResponse> = (metadata: grpc.Metadata, options?: Partial<grpc.CallOptions>) => grpc.ClientDuplexStream<TRequest, TResponse>;
+export type DuplexMethod<TRequest, TResponse> = (metadata: grpc.Metadata, options: Partial<grpc.CallOptions>) => grpc.ClientDuplexStream<TRequest, TResponse>;

--- a/Source/services/ReactiveGrpc.ts
+++ b/Source/services/ReactiveGrpc.ts
@@ -74,7 +74,8 @@ export function reactiveClientStream<TRequest, TResponse>(client: grpc.Client, m
  */
 export function reactiveServerStream<TArgument, TResponse>(client: grpc.Client, method: ServerStreamMethod<TArgument, TResponse>, argument: TArgument, cancellation: Cancellation): Observable<TResponse> {
     const subject = new Subject<TResponse>();
-    const stream = method.call(client, argument, null, null);
+    const metadata = new grpc.Metadata();
+    const stream = method.call(client, argument, metadata, {});
     handleCancellation(stream, cancellation);
     handleServerResponses(stream, subject);
     return subject;

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -45,9 +45,9 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/concepts": "6.0.0-gimli.0",
+        "@dolittle/concepts": "6.0.0",
         "@dolittle/contracts": "6.5.0",
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.common": "21.0.0",
         "@dolittle/sdk.dependencyinversion": "21.0.0",
         "@dolittle/sdk.execution": "21.0.0",

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0-gimli.0",
-        "@dolittle/contracts": "6.4.0",
+        "@dolittle/contracts": "6.5.0",
         "@dolittle/rudiments": "6.0.0-gimli.0",
         "@dolittle/sdk.common": "21.0.0",
         "@dolittle/sdk.dependencyinversion": "21.0.0",

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -53,6 +53,7 @@
         "@dolittle/sdk.execution": "21.0.0",
         "@dolittle/sdk.protobuf": "21.0.0",
         "@dolittle/sdk.resilience": "21.0.0",
+        "@grpc/grpc-js": "1.2.12",
         "rxjs": "6.6.0",
         "winston": "3.3.2"
     }

--- a/Source/tenancy/package.json
+++ b/Source/tenancy/package.json
@@ -44,7 +44,7 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/rudiments": "6.0.0-gimli.0",
+        "@dolittle/rudiments": "6.0.0",
         "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.execution": "21.0.0",
         "@dolittle/sdk.protobuf": "21.0.0",

--- a/Source/tenancy/package.json
+++ b/Source/tenancy/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@dolittle/rudiments": "6.0.0-gimli.0",
-        "@dolittle/runtime.contracts": "6.4.0",
+        "@dolittle/runtime.contracts": "6.5.0",
         "@dolittle/sdk.execution": "21.0.0",
         "@dolittle/sdk.protobuf": "21.0.0",
         "@dolittle/sdk.resilience": "21.0.0",


### PR DESCRIPTION
## Summary

Uses the new batch streaming method to get all Projection states from the Runtime. This fixes an issue where a large amount of Projection states caused the gRPC client in the SDK to throw an exception because the response message was too big. Also fixed some gRPC method internals that we haven't used before (server streaming calls), and fixed the references to JavaScript.Fundamentals pre-release packages.

### Fixed

- The `IProjectionStore.getAll` method now uses the new gRPC method that streams results back in batches to fix the issue of too large gRPC messages when a large amount of projection read models have been created.