### PR TITLE
Simplify Projection Store API

### DIFF
--- a/Samples/ExpressJS/DishCounter.ts
+++ b/Samples/ExpressJS/DishCounter.ts
@@ -9,10 +9,12 @@ import { DishPrepared } from './DishPrepared';
 
 @projection('98f9db66-b6ca-4e5f-9fc3-638626c9ecfa')
 export class DishCounter {
+    dish: string = 'Unknown';
     numberOfTimesPrepared: number = 0;
 
     @on(DishPrepared, _ => _.keyFromProperty('Dish'))
     on(event: DishPrepared, projectionContext: ProjectionContext) {
+        this.dish = event.Dish;
         this.numberOfTimesPrepared ++;
     }
 }

--- a/Samples/ExpressJS/DishCounter.ts
+++ b/Samples/ExpressJS/DishCounter.ts
@@ -9,12 +9,12 @@ import { DishPrepared } from './DishPrepared';
 
 @projection('98f9db66-b6ca-4e5f-9fc3-638626c9ecfa')
 export class DishCounter {
-    dish: string = 'Unknown';
+    name: string = 'Unknown';
     numberOfTimesPrepared: number = 0;
 
     @on(DishPrepared, _ => _.keyFromProperty('Dish'))
     on(event: DishPrepared, projectionContext: ProjectionContext) {
-        this.dish = event.Dish;
+        this.name = event.Dish;
         this.numberOfTimesPrepared ++;
     }
 }

--- a/Samples/ExpressJS/index.ts
+++ b/Samples/ExpressJS/index.ts
@@ -32,8 +32,6 @@ application.get(
         (req, res, next, projections, logger: Logger) => {
             logger.info('Received reqest to get DishCounter projection');
             projections.getAll(DishCounter)
-                .then(result => Array.from(result.values()))
-                .then(results => results.map(({ key, state }) => ({ dish: key.value, ...state })))
                 .then(result => res.json(result))
                 .catch(next);
         }

--- a/Samples/Tutorials/Projections/DishCounter.ts
+++ b/Samples/Tutorials/Projections/DishCounter.ts
@@ -9,10 +9,12 @@ import { DishPrepared } from './DishPrepared';
 
 @projection('98f9db66-b6ca-4e5f-9fc3-638626c9ecfa')
 export class DishCounter {
+    dish: string = 'Unknown';
     numberOfTimesPrepared: number = 0;
 
     @on(DishPrepared, _ => _.keyFromProperty('Dish'))
     on(event: DishPrepared, projectionContext: ProjectionContext) {
+        this.dish = event.Dish;
         this.numberOfTimesPrepared ++;
     }
 }

--- a/Samples/Tutorials/Projections/DishCounter.ts
+++ b/Samples/Tutorials/Projections/DishCounter.ts
@@ -9,12 +9,12 @@ import { DishPrepared } from './DishPrepared';
 
 @projection('98f9db66-b6ca-4e5f-9fc3-638626c9ecfa')
 export class DishCounter {
-    dish: string = 'Unknown';
+    name: string = 'Unknown';
     numberOfTimesPrepared: number = 0;
 
     @on(DishPrepared, _ => _.keyFromProperty('Dish'))
     on(event: DishPrepared, projectionContext: ProjectionContext) {
-        this.dish = event.Dish;
+        this.name = event.Dish;
         this.numberOfTimesPrepared ++;
     }
 }

--- a/Samples/Tutorials/Projections/index.ts
+++ b/Samples/Tutorials/Projections/index.ts
@@ -35,8 +35,8 @@ import { DishPrepared } from './DishPrepared';
 
     await setTimeout(1000);
 
-    for (const { dish, numberOfTimesPrepared } of await client.projections.forTenant(TenantId.development).getAll(DishCounter)) {
-        client.logger.info(`The kitchen has prepared ${dish} ${numberOfTimesPrepared} times`);
+    for (const { name, numberOfTimesPrepared } of await client.projections.forTenant(TenantId.development).getAll(DishCounter)) {
+        client.logger.info(`The kitchen has prepared ${name} ${numberOfTimesPrepared} times`);
     }
 
     const chef = await client.projections.forTenant(TenantId.development).get<Chef>(Chef, 'Mrs. Tex Mex');

--- a/Samples/Tutorials/Projections/index.ts
+++ b/Samples/Tutorials/Projections/index.ts
@@ -40,5 +40,5 @@ import { DishPrepared } from './DishPrepared';
     }
 
     const chef = await client.projections.forTenant(TenantId.development).get<Chef>(Chef, 'Mrs. Tex Mex');
-    client.logger.info(`${chef.name} has prepared ${chef.dishes}`);
+    client.logger.info(`${chef.name} has prepared ${chef.dishes.join(', ')}`);
 })();

--- a/Samples/Tutorials/Projections/index.ts
+++ b/Samples/Tutorials/Projections/index.ts
@@ -35,10 +35,10 @@ import { DishPrepared } from './DishPrepared';
 
     await setTimeout(1000);
 
-    for (const [dish, { state: counter }] of await client.projections.forTenant(TenantId.development).getAll(DishCounter)) {
-        client.logger.info(`The kitchen has prepared ${dish} ${counter.numberOfTimesPrepared} times`);
+    for (const { dish, numberOfTimesPrepared } of await client.projections.forTenant(TenantId.development).getAll(DishCounter)) {
+        client.logger.info(`The kitchen has prepared ${dish} ${numberOfTimesPrepared} times`);
     }
 
     const chef = await client.projections.forTenant(TenantId.development).get<Chef>(Chef, 'Mrs. Tex Mex');
-    client.logger.info(`${chef.key} has prepared ${chef.state.dishes}`);
+    client.logger.info(`${chef.name} has prepared ${chef.dishes}`);
 })();

--- a/Source/projections/Store/IProjectionStore.ts
+++ b/Source/projections/Store/IProjectionStore.ts
@@ -16,6 +16,106 @@ import { CurrentState } from './CurrentState';
  */
 export abstract class IProjectionStore {
     /**
+     * Gets a projection read model by key for a projection associated with a type.
+     * @param {Constructor<TProjection>} type - The type of the projection.
+     * @param {Key | any} key - The key of the projection.
+     * @param {Cancellation} [cancellation] - The cancellation token.
+     * @returns {Promise<TProjection>} A {@link Promise} that when resolved returns the read model of the projection.
+     * @template TProjection The type of the projection.
+     */
+    abstract get<TProjection>(type: Constructor<TProjection>, key: Key | any, cancellation?: Cancellation): Promise<TProjection>;
+
+    /**
+     * Gets a projection read model by key for a projection specified by projection identifier.
+     * @param {Constructor<TProjection>} type - The type of the projection.
+     * @param {Key | any} key - The key of the projection.
+     * @param {ProjectionId | Guid | string} projection - The id of the projection.
+     * @param {Cancellation} [cancellation] - The cancellation token.
+     * @returns {Promise<TProjection>} A {@link Promise} that when resolved returns the read model of the projection.
+     * @template TProjection The type of the projection.
+     */
+    abstract get<TProjection>(type: Constructor<TProjection>, key: Key | any, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<TProjection>;
+
+    /**
+     * Gets a projection read model by key for a projection specified by projection and scope identifier.
+     * @param {Constructor<TProjection>} type - The type of the projection.
+     * @param {Key | any} key - The key of the projection.
+     * @param {ProjectionId | Guid | string} projection - The id of the projection.
+     * @param {ScopeId | Guid | string} scope - The scope the projection in.
+     * @param {Cancellation} [cancellation] - The cancellation token.
+     * @returns {Promise<TProjection>} A {@link Promise} that when resolved returns the read model of the projection.
+     * @template TProjection The type of the projection.
+     */
+    abstract get<TProjection>(type: Constructor<TProjection>, key: Key | any, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<TProjection>;
+
+    /**
+     * Gets a projection read model by key for a projection specified by projection identifier.
+     * @param {Key | any} key - The key of the projection.
+     * @param {ProjectionId | Guid | string} projection - The id of the projection.
+     * @param {Cancellation} [cancellation] - The cancellation token.
+     * @returns {Promise<any>} A {@link Promise} that when resolved returns the read model of the projection.
+     */
+    abstract get(key: Key | any, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<any>;
+
+    /**
+     * Gets a projection read model by key for a projection specified by projection and scope identifier.
+     * @param {Key | any} key - The key of the projection.
+     * @param {ProjectionId | Guid | string} projection - The id of the projection.
+     * @param {ScopeId | Guid | string} scpåe - The scope the projection in.
+     * @param {Cancellation} [cancellation] - The cancellation token.
+     * @returns {Promise<any>} A {@link Promise} that when resolved returns the read model of the projection.
+     */
+    abstract get(key: Key | any, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<any>;
+
+    /**
+     * Gets all projection read models for a projection associated with a type.
+     * @template T
+     * @param {Constructor<T>} type - The type of the projection.
+     * @param {Cancellation} [cancellation] - The cancellation token.
+     * @returns {Promise<TProjection[]>} A {@link Promise} that when resolved returns the all the read models of the projection.
+     * @template TProjection The type of the projection.
+     */
+    abstract getAll<TProjection>(type: Constructor<TProjection>, cancellation?: Cancellation): Promise<TProjection[]>;
+
+    /**
+     * Gets all projection read models for a projection specified by projection identifier.
+     * @param {Constructor<TProjection>} type - The type of the projection.
+     * @param {ProjectionId | Guid | string} projection - The id of the projection.
+     * @param {Cancellation} [cancellation] - The cancellation token.
+     * @returns {Promise<TProjection[]>} A {@link Promise} that when resolved returns the all the read models of the projection.
+     * @template TProjection The type of the projection.
+     */
+    abstract getAll<TProjection>(type: Constructor<TProjection>, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<TProjection[]>;
+
+    /**
+     * Gets all projection read models for a projection specified by projection and scope identifier.
+     * @param {Constructor<TProjection>} type - The type of the projection.
+     * @param {ProjectionId | Guid | string} projection - The id of the projection.
+     * @param {ScopeId | Guid | string} scope - The scope the projection in.
+     * @param {Cancellation} [cancellation] - The cancellation token.
+     * @returns {Promise<TProjection[]>} A {@link Promise} that when resolved returns the all the read models of the projection.
+     * @template TProjection The type of the projection.
+     */
+    abstract getAll<TProjection>(type: Constructor<TProjection>, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<TProjection[]>;
+
+    /**
+     * Gets all projection read models for a projection specified by projection identifier.
+     * @param {ProjectionId | Guid | string} projection - The id of the projection.
+     * @param {Cancellation} [cancellation] - The cancellation token.
+     * @returns {Promise<any[]>} A {@link Promise} that when resolved returns the all the read models of the projection.
+     */
+    abstract getAll(projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<any[]>;
+
+    /**
+     * Gets all projection read models for a projection specified by projection and scope identifier.
+     * @param {ProjectionId | Guid | string} projection - The id of the projection.
+     * @param {ScopeId | Guid | string} scope - The scope the projection in.
+     * @param {Cancellation} [cancellation] - The cancellation token.
+     * @returns {Promise<any[]>} A {@link Promise} that when resolved returns the all the read models of the projection.
+     */
+    abstract getAll(projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<any[]>;
+
+    /**
      * Gets a projection state by key for a projection associated with a type.
      * @param {Constructor<TProjection>} type - The type of the projection.
      * @param {Key | any} key - The key of the projection.
@@ -23,7 +123,7 @@ export abstract class IProjectionStore {
      * @returns {Promise<CurrentState<TProjection>>} A {@link Promise} that when resolved returns the current state of the projection.
      * @template TProjection The type of the projection.
      */
-    abstract get<TProjection>(type: Constructor<TProjection>, key: Key | any, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
+    abstract getState<TProjection>(type: Constructor<TProjection>, key: Key | any, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
 
     /**
      * Gets a projection state by key for a projection specified by projection identifier.
@@ -34,7 +134,7 @@ export abstract class IProjectionStore {
      * @returns {Promise<CurrentState<TProjection>>} A {@link Promise} that when resolved returns the current state of the projection.
      * @template TProjection The type of the projection.
      */
-    abstract get<TProjection>(type: Constructor<TProjection>, key: Key | any, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
+    abstract getState<TProjection>(type: Constructor<TProjection>, key: Key | any, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
 
     /**
      * Gets a projection state by key for a projection specified by projection and scope identifier.
@@ -46,7 +146,7 @@ export abstract class IProjectionStore {
      * @returns {Promise<CurrentState<TProjection>>} A {@link Promise} that when resolved returns the current state of the projection.
      * @template TProjection The type of the projection.
      */
-    abstract get<TProjection>(type: Constructor<TProjection>, key: Key | any, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
+    abstract getState<TProjection>(type: Constructor<TProjection>, key: Key | any, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<TProjection>>;
 
     /**
      * Gets a projection state by key for a projection specified by projection identifier.
@@ -55,7 +155,7 @@ export abstract class IProjectionStore {
      * @param {Cancellation} [cancellation] - The cancellation token.
      * @returns {Promise<CurrentState<any>>} A {@link Promise} that when resolved returns the current state of the projection.
      */
-    abstract get(key: Key | any, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<any>>;
+    abstract getState(key: Key | any, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<any>>;
 
     /**
      * Gets a projection state by key for a projection specified by projection and scope identifier.
@@ -65,53 +165,5 @@ export abstract class IProjectionStore {
      * @param {Cancellation} [cancellation] - The cancellation token.
      * @returns {Promise<CurrentState<any>>} A {@link Promise} that when resolved returns the current state of the projection.
      */
-    abstract get(key: Key | any, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<any>>;
-
-    /**
-     * Gets all projection states for a projection associated with a type.
-     * @template T
-     * @param {Constructor<T>} type - The type of the projection.
-     * @param {Cancellation} [cancellation] - The cancellation token.
-     * @returns {Promise<Map<Key, CurrentState<TProjection>>>} A {@link Promise} that when resolved returns the current state of all projections.
-     * @template TProjection The type of the projection.
-     */
-    abstract getAll<TProjection>(type: Constructor<TProjection>, cancellation?: Cancellation): Promise<Map<Key, CurrentState<TProjection>>>;
-
-    /**
-     * Gets all projection states for a projection specified by projection identifier.
-     * @param {Constructor<TProjection>} type - The type of the projection.
-     * @param {ProjectionId | Guid | string} projection - The id of the projection.
-     * @param {Cancellation} [cancellation] - The cancellation token.
-     * @returns {Promise<Map<Key, CurrentState<TProjection>>>} A {@link Promise} that when resolved returns the current state of all projections.
-     * @template TProjection The type of the projection.
-     */
-    abstract getAll<TProjection>(type: Constructor<TProjection>, projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<Map<Key, CurrentState<TProjection>>>;
-
-    /**
-     * Gets all projection states for a projection specified by projection and scope identifier.
-     * @param {Constructor<TProjection>} type - The type of the projection.
-     * @param {ProjectionId | Guid | string} projection - The id of the projection.
-     * @param {ScopeId | Guid | string} scope - The scope the projection in.
-     * @param {Cancellation} [cancellation] - The cancellation token.
-     * @returns {Promise<Map<Key, CurrentState<TProjection>>>} A {@link Promise} that when resolved returns the current state of all projections.
-     * @template TProjection The type of the projection.
-     */
-    abstract getAll<TProjection>(type: Constructor<TProjection>, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<Map<Key, CurrentState<TProjection>>>;
-
-    /**
-     * Gets all projection states for a projection specified by projection identifier.
-     * @param {ProjectionId | Guid | string} projection - The id of the projection.
-     * @param {Cancellation} [cancellation] - The cancellation token.
-     * @returns {Promise<Map<Key, CurrentState<any>>>} A {@link Promise} that when resolved returns the current state of all projections.
-     */
-    abstract getAll(projection: ProjectionId | Guid | string, cancellation?: Cancellation): Promise<Map<Key,CurrentState<any>>>;
-
-    /**
-     * Gets all projection states for a projection specified by projection and scope identifier.
-     * @param {ProjectionId | Guid | string} projection - The id of the projection.
-     * @param {ScopeId | Guid | string} scope - The scope the projection in.
-     * @param {Cancellation} [cancellation] - The cancellation token.
-     * @returns {Promise<Map<Key, CurrentState<any>>>} A {@link Promise} that when resolved returns the current state of all projections.
-     */
-    abstract getAll(projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<Map<Key, CurrentState<any>>>;
+    abstract getState(key: Key | any, projection: ProjectionId | Guid | string, scope: ScopeId | Guid | string, cancellation?: Cancellation): Promise<CurrentState<any>>;
 }

--- a/Source/projections/Store/WrongKeyReceivedFromRuntime.ts
+++ b/Source/projections/Store/WrongKeyReceivedFromRuntime.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Exception } from '@dolittle/rudiments';
+import { ScopeId } from '@dolittle/sdk.events';
+
+import { Key } from '../Key';
+import { ProjectionId } from '../ProjectionId';
+
+/**
+ * The exception that gets thrown when the Runtime responds with a projection state with a wrong key when getting a single projection state from the store.
+ */
+export class WrongKeyReceivedFromRuntime extends Exception {
+    /**
+     * Initialises a new instance of the {@link WrongKeyReceivedFromRuntime} class.
+     * @param {ProjectionId} projection - The projection identifier.
+     * @param {ScopeId} scope - The scope identifier for the projection.
+     * @param {Key} expectedKey - The key that was requested.
+     * @param {string} receivedKey - The key that was received.
+     */
+    constructor(projection: ProjectionId, scope: ScopeId, expectedKey: Key, receivedKey: string) {
+        super(`A projection state with the wrong key was returned by the Runtime for Projection ${projection} in Scope ${scope}. Expected '${expectedKey.value}', received '${receivedKey}'`);
+    }
+}

--- a/Source/projections/Store/for_ProjectionStore/given.ts
+++ b/Source/projections/Store/for_ProjectionStore/given.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { ClientReadableStream } from '@grpc/grpc-js';
+import { ClientReadableStream, ClientUnaryCall, InterceptingCall, ServiceError } from '@grpc/grpc-js';
 import { EventEmitter } from 'stream';
-import { stubInterface } from 'ts-sinon';
+import sinon, { stubInterface } from 'ts-sinon';
 import { Logger } from 'winston';
 
 import { Claims, CorrelationId, Environment, ExecutionContext, MicroserviceId, TenantId, Version } from '@dolittle/sdk.execution';
 
 import { ProjectionsClient } from '@dolittle/runtime.contracts/Projections/Store_grpc_pb';
-import { GetAllResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
+import { GetAllResponse, GetOneResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
 
 import { IProjectionReadModelTypes } from '../IProjectionReadModelTypes';
 import { ProjectionReadModelTypes } from '../ProjectionReadModelTypes';
@@ -32,6 +32,17 @@ export default {
 
     get empty_read_model_types(): IProjectionReadModelTypes {
         return new ProjectionReadModelTypes();
+    },
+
+    projections_client_with_get_one_response(response?: GetOneResponse, error?: ServiceError): ProjectionsClient {
+        const projections_client = stubInterface<ProjectionsClient>();
+
+        projections_client.getOne.callsFake((_, __, ___, callback) => {
+            setTimeout(() => callback(error ?? null, response as any), 0);
+            return new EventEmitter() as ClientUnaryCall;
+        });
+
+        return projections_client;
     },
 
     get projections_client_and_get_all_stream(): [ProjectionsClient, ClientReadableStream<GetAllResponse>] {

--- a/Source/projections/Store/for_ProjectionStore/given/a_projection_type.ts
+++ b/Source/projections/Store/for_ProjectionStore/given/a_projection_type.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export class a_projection_type {
+    aValue: number = 42;
+}

--- a/Source/projections/Store/for_ProjectionStore/when_getting/by_ids/and_it_returns_a_failure.ts
+++ b/Source/projections/Store/for_ProjectionStore/when_getting/by_ids/and_it_returns_a_failure.ts
@@ -2,20 +2,25 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { describeThis } from '@dolittle/typescript.testing';
+import { Guid } from '@dolittle/rudiments';
 
 import { Cancellation } from '@dolittle/sdk.resilience';
+import { Guids } from '@dolittle/sdk.protobuf';
 
 import { Failure } from '@dolittle/contracts/Protobuf/Failure_pb';
-import { GetAllResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
+import { GetOneResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
 
 import given from '../../given';
 import { ProjectionStore } from '../../../ProjectionStore';
 import { FailedToGetProjection } from '../../../FailedToGetProjection';
-import { Guids } from '@dolittle/sdk.protobuf';
-import { Guid } from '@dolittle/rudiments';
 
 describeThis(__filename, () => {
-    const [projections_client, server_stream] = given.projections_client_and_get_all_stream;
+    const failure = new Failure();
+    failure.setId(Guids.toProtobuf(Guid.create()));
+    const response = new GetOneResponse();
+    response.setFailure(failure);
+
+    const projections_client = given.projections_client_with_get_one_response(response);
 
     const projection_store = new ProjectionStore(
         projections_client,
@@ -23,15 +28,8 @@ describeThis(__filename, () => {
         given.empty_read_model_types,
         given.a_logger);
 
-    const result = projection_store.getAll('ab3be0d3-e550-4ac0-8646-87f376d3d1b0', '6f428480-4cb6-4454-b52d-dd453f6e8a98', Cancellation.default);
+    const result = projection_store.get('key', 'ab3be0d3-e550-4ac0-8646-87f376d3d1b0', '6f428480-4cb6-4454-b52d-dd453f6e8a98', Cancellation.default);
     result.catch();
-
-    const failure = new Failure();
-    failure.setId(Guids.toProtobuf(Guid.create()));
-    const response = new GetAllResponse();
-    response.setFailure(failure);
-    server_stream.emit('data', response);
-    server_stream.emit('end');
 
     it('should throw an exception', () => result.should.eventually.be.rejectedWith(FailedToGetProjection));
 });

--- a/Source/projections/Store/for_ProjectionStore/when_getting/by_ids/and_it_returns_the_wrong_key.ts
+++ b/Source/projections/Store/for_ProjectionStore/when_getting/by_ids/and_it_returns_the_wrong_key.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+
+import { Cancellation } from '@dolittle/sdk.resilience';
+
+import { Failure } from '@dolittle/contracts/Protobuf/Failure_pb';
+import { ProjectionCurrentState, ProjectionCurrentStateType } from '@dolittle/runtime.contracts/Projections/State_pb';
+import { GetOneResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
+
+import given from '../../given';
+import { ProjectionStore } from '../../../ProjectionStore';
+import { WrongKeyReceivedFromRuntime } from '../../../WrongKeyReceivedFromRuntime';
+
+describeThis(__filename, () => {
+    const response = new GetOneResponse();
+    const currentState = new ProjectionCurrentState();
+    currentState.setKey('some other key');
+    currentState.setState('{}');
+    response.setState(currentState);
+
+    const projections_client = given.projections_client_with_get_one_response(response);
+
+    const projection_store = new ProjectionStore(
+        projections_client,
+        given.an_execution_context,
+        given.empty_read_model_types,
+        given.a_logger);
+
+    const result = projection_store.get('key', 'ab3be0d3-e550-4ac0-8646-87f376d3d1b0', '6f428480-4cb6-4454-b52d-dd453f6e8a98', Cancellation.default);
+    result.catch();
+
+    it('should throw an exception', () => result.should.eventually.be.rejectedWith(WrongKeyReceivedFromRuntime));
+});

--- a/Source/projections/Store/for_ProjectionStore/when_getting_all/by_ids/and_it_returns_multiple_batches.ts
+++ b/Source/projections/Store/for_ProjectionStore/when_getting_all/by_ids/and_it_returns_multiple_batches.ts
@@ -24,8 +24,6 @@ describeThis(__filename, () => {
         given.a_logger);
 
     const result = projection_store.getAll('ab3be0d3-e550-4ac0-8646-87f376d3d1b0', '6f428480-4cb6-4454-b52d-dd453f6e8a98', Cancellation.default);
-    const keys = result.then(_ => Array.from(_.keys()));
-    const entries = result.then(_ => Array.from(_.entries()));
 
     const first_state = new ProjectionCurrentState();
     first_state.setKey('first key');
@@ -49,21 +47,9 @@ describeThis(__filename, () => {
     server_stream.emit('data', second_batch);
     server_stream.emit('end');
 
-    it('should return all 3 keys', () => keys.should.eventually.have.deep.members([
-        Key.from('first key'),
-        Key.from('second key'),
-        Key.from('third key'),
-    ]));
-    it('should return the first state for the first key', () => entries.should.eventually.deep.include([
-        Key.from('first key'),
-        new CurrentState(CurrentStateType.CreatedFromInitialState, { first: 'state' }, Key.from('first key')),
-    ]));
-    it('should return the second state for the second key', () => entries.should.eventually.deep.include([
-        Key.from('second key'),
-        new CurrentState(CurrentStateType.CreatedFromInitialState, { second: 'state' }, Key.from('second key')),
-    ]));
-    it('should return the third state for the third key', () => entries.should.eventually.deep.include([
-        Key.from('third key'),
-        new CurrentState(CurrentStateType.CreatedFromInitialState, { third: 'state' }, Key.from('third key')),
+    it('should return all 3 states', () => result.should.eventually.have.deep.members([
+        { first: 'state' },
+        { second: 'state' },
+        { third: 'state' },
     ]));
 });

--- a/Source/projections/Store/for_ProjectionStore/when_getting_all/by_type/and_it_returns_a_failure.ts
+++ b/Source/projections/Store/for_ProjectionStore/when_getting_all/by_type/and_it_returns_a_failure.ts
@@ -4,34 +4,37 @@
 import { describeThis } from '@dolittle/typescript.testing';
 
 import { Cancellation } from '@dolittle/sdk.resilience';
+import { ScopeId } from '@dolittle/sdk.events';
 
 import { Failure } from '@dolittle/contracts/Protobuf/Failure_pb';
 import { GetAllResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
 
 import given from '../../given';
+import { a_projection_type } from '../../given/a_projection_type';
 import { ProjectionStore } from '../../../ProjectionStore';
-import { FailedToGetProjection } from '../../../FailedToGetProjection';
-import { Guids } from '@dolittle/sdk.protobuf';
-import { Guid } from '@dolittle/rudiments';
+import { ScopedProjectionId } from '../../../ScopedProjectionId';
+import { ProjectionId } from '../../../../ProjectionId';
 
 describeThis(__filename, () => {
     const [projections_client, server_stream] = given.projections_client_and_get_all_stream;
 
+    const read_model_types = given.empty_read_model_types;
+    read_model_types.associate(a_projection_type, new ScopedProjectionId(ProjectionId.from('3f1688f2-1e21-4a2e-bb19-c3c88aecb0b'), ScopeId.default));
+
     const projection_store = new ProjectionStore(
         projections_client,
         given.an_execution_context,
-        given.empty_read_model_types,
+        read_model_types,
         given.a_logger);
 
-    const result = projection_store.getAll('ab3be0d3-e550-4ac0-8646-87f376d3d1b0', '6f428480-4cb6-4454-b52d-dd453f6e8a98', Cancellation.default);
+    const result = projection_store.getAll(a_projection_type, Cancellation.default);
     result.catch();
 
     const failure = new Failure();
-    failure.setId(Guids.toProtobuf(Guid.create()));
     const response = new GetAllResponse();
     response.setFailure(failure);
     server_stream.emit('data', response);
     server_stream.emit('end');
 
-    it('should throw an exception', () => result.should.eventually.be.rejectedWith(FailedToGetProjection));
+    it('should throw an exception', () => result.should.eventually.be.rejected);
 });

--- a/Source/projections/Store/for_ProjectionStore/when_getting_all/by_type/and_it_returns_multiple_batches.ts
+++ b/Source/projections/Store/for_ProjectionStore/when_getting_all/by_type/and_it_returns_multiple_batches.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+
+import { Cancellation } from '@dolittle/sdk.resilience';
+
+import { GetAllResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
+import { ProjectionCurrentState } from '@dolittle/runtime.contracts/Projections/State_pb';
+
+import given from '../../given';
+import { ProjectionStore } from '../../../ProjectionStore';
+import { a_projection_type } from '../../given/a_projection_type';
+import { ScopedProjectionId } from '../../../ScopedProjectionId';
+import { ProjectionId } from '../../../../ProjectionId';
+import { ScopeId } from '@dolittle/sdk.events';
+
+describeThis(__filename, () => {
+    const [projections_client, server_stream] = given.projections_client_and_get_all_stream;
+
+    const read_model_types = given.empty_read_model_types;
+    read_model_types.associate(a_projection_type, new ScopedProjectionId(ProjectionId.from('3f1688f2-1e21-4a2e-bb19-c3c88aecb0b'), ScopeId.default));
+
+    const projection_store = new ProjectionStore(
+        projections_client,
+        given.an_execution_context,
+        read_model_types,
+        given.a_logger);
+
+    const result = projection_store.getAll(a_projection_type, Cancellation.default);
+
+    const first_state_projection = new a_projection_type();
+    const first_state = new ProjectionCurrentState();
+    first_state.setKey('first key');
+    first_state.setState('{ "aValue": "123" }');
+
+    const second_state = new ProjectionCurrentState();
+    second_state.setKey('second key');
+    second_state.setState('{ "aValue": "1337" }');
+
+    const third_state = new ProjectionCurrentState();
+    third_state.setKey('third key');
+    third_state.setState('{ "aValue": "43" }');
+
+    const first_batch = new GetAllResponse();
+    first_batch.setStatesList([first_state, second_state]);
+
+    const second_batch = new GetAllResponse();
+    second_batch.setStatesList([third_state]);
+
+    server_stream.emit('data', first_batch);
+    server_stream.emit('data', second_batch);
+    server_stream.emit('end');
+
+    it('should return the correct type', () => result.should.eventually.satisfy((all: any[]) => all.every(read_model => read_model instanceof a_projection_type)));
+    it('should return all 3 states', () => result.should.eventually.have.deep.members([
+        { aValue: '123' },
+        { aValue: '1337' },
+        { aValue: '43' },
+    ]));
+});

--- a/Source/projections/Store/for_ProjectionStore/when_getting_all/by_type/and_it_returns_the_same_key_multple_times.ts
+++ b/Source/projections/Store/for_ProjectionStore/when_getting_all/by_type/and_it_returns_the_same_key_multple_times.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+
+import { Cancellation } from '@dolittle/sdk.resilience';
+
+import { GetAllResponse } from '@dolittle/runtime.contracts/Projections/Store_pb';
+import { ProjectionCurrentState } from '@dolittle/runtime.contracts/Projections/State_pb';
+
+import given from '../../given';
+import { ProjectionStore } from '../../../ProjectionStore';
+import { ReceivedDuplicateProjectionKeys } from '../../../ReceivedDuplicateProjectionKeys';
+import { a_projection_type } from '../../given/a_projection_type';
+import { ScopedProjectionId } from '../../../ScopedProjectionId';
+import { ProjectionId } from '../../../../ProjectionId';
+import { ScopeId } from '@dolittle/sdk.events';
+
+describeThis(__filename, () => {
+    const [projections_client, server_stream] = given.projections_client_and_get_all_stream;
+
+    const read_model_types = given.empty_read_model_types;
+    read_model_types.associate(a_projection_type, new ScopedProjectionId(ProjectionId.from('3f1688f2-1e21-4a2e-bb19-c3c88aecb0b'), ScopeId.default));
+
+    const projection_store = new ProjectionStore(
+        projections_client,
+        given.an_execution_context,
+        read_model_types,
+        given.a_logger);
+
+    const result = projection_store.getAll(a_projection_type, Cancellation.default);
+    result.catch();
+
+    const first_state = new ProjectionCurrentState();
+    first_state.setKey('first key');
+    first_state.setState('{ "aValue": "42" }');
+
+    const second_state = new ProjectionCurrentState();
+    second_state.setKey('first key');
+    second_state.setState('{ "aValue": "44" }');
+
+    const first_batch = new GetAllResponse();
+    first_batch.setStatesList([first_state, second_state]);
+
+    server_stream.emit('data', first_batch);
+    server_stream.emit('end');
+
+    it('should throw an exception', () => result.should.eventually.be.rejectedWith(ReceivedDuplicateProjectionKeys));
+});


### PR DESCRIPTION
## Summary

Simplifies the `IProjectionStore` apis by removing the `CurrentState<>` wrapper around the returned types from `get(...)` and `getAll(...)` methods, and returns an array instead of a `Map` when getting multiple read models. And introduces a new `getState(...)` method that has the wrapped types for when it is interesting.

### Added

- `IProjectionStore.getState(...)` method that keeps the syntax of the previous `.get(...)` method.

### Changed

- `IProjectionStore.get(...)` returns the specified type or `any` instead of wrapping with `CurrentState<>`
- `IProjectionStore.getAll(...)` returns an array of the specified type or `any` instead of a `Map` of keys to `CurrentState<>`.
