### PR TITLE
Implement explicit builder API for MongoDB copies.

### DIFF
--- a/Samples/Tutorials/Projections/Chef.ts
+++ b/Samples/Tutorials/Projections/Chef.ts
@@ -6,6 +6,7 @@
 export class Chef {
     constructor(
         public name: string = '',
-        public dishes: string[] = []
+        public dishes: string[] = [],
+        public lastPreparedDish: Date = new Date(0),
     ) { }
 }

--- a/Samples/Tutorials/Projections/index.ts
+++ b/Samples/Tutorials/Projections/index.ts
@@ -19,7 +19,7 @@ import { DishPrepared } from './DishPrepared';
                 .create('0767bc04-bc03-40b8-a0be-5f6c6130f68b')
                     .forReadModel(Chef)
                     .copyToMongoDB(_ => _
-                        .convert('lastPreparedDish', MongoDBConversion.DateTime)
+                        .withConversion('lastPreparedDish', MongoDBConversion.DateTime)
                     )
                     .on(DishPrepared, _ => _.keyFromProperty('Chef'), (chef, event, projectionContext) => {
                         chef.name = event.Chef;

--- a/Samples/Tutorials/Projections/index.ts
+++ b/Samples/Tutorials/Projections/index.ts
@@ -5,6 +5,7 @@
 
 import { DolittleClient } from '@dolittle/sdk';
 import { TenantId } from '@dolittle/sdk.execution';
+import { MongoDBConversion } from '@dolittle/sdk.projections';
 import { setTimeout } from 'timers/promises';
 
 import { Chef } from './Chef';
@@ -17,8 +18,12 @@ import { DishPrepared } from './DishPrepared';
             .withProjections(_ => _
                 .create('0767bc04-bc03-40b8-a0be-5f6c6130f68b')
                     .forReadModel(Chef)
+                    .copyToMongoDB(_ => _
+                        .convert('lastPreparedDish', MongoDBConversion.DateTime)
+                    )
                     .on(DishPrepared, _ => _.keyFromProperty('Chef'), (chef, event, projectionContext) => {
                         chef.name = event.Chef;
+                        chef.lastPreparedDish = new Date();
                         if (!chef.dishes.includes(event.Dish)) chef.dishes.push(event.Dish);
                         return chef;
                     })

--- a/Source/artifacts/package.json
+++ b/Source/artifacts/package.json
@@ -47,7 +47,7 @@
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/types": "6.0.0",
-        "@dolittle/runtime.contracts": "6.5.0"
+        "@dolittle/runtime.contracts": "6.6.0-sam.0"
     },
     "devDependencies": {
         "@types/is-natural-number": "^4.0.0"

--- a/Source/embeddings/package.json
+++ b/Source/embeddings/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.5.0",
+        "@dolittle/contracts": "6.6.0-sam.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.5.0",
+        "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.artifacts": "22.1.0",
         "@dolittle/sdk.common": "22.1.0",
         "@dolittle/sdk.dependencyinversion": "22.1.0",

--- a/Source/eventHorizon/package.json
+++ b/Source/eventHorizon/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.5.0",
+        "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.events": "22.1.0",
         "@dolittle/sdk.execution": "22.1.0",
         "@dolittle/sdk.protobuf": "22.1.0",

--- a/Source/events.filtering/package.json
+++ b/Source/events.filtering/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.5.0",
+        "@dolittle/contracts": "6.6.0-sam.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.5.0",
+        "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.common": "22.1.0",
         "@dolittle/sdk.dependencyinversion": "22.1.0",
         "@dolittle/sdk.events": "22.1.0",

--- a/Source/events.handling/package.json
+++ b/Source/events.handling/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.5.0",
+        "@dolittle/contracts": "6.6.0-sam.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.5.0",
+        "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.artifacts": "22.1.0",
         "@dolittle/sdk.common": "22.1.0",
         "@dolittle/sdk.dependencyinversion": "22.1.0",

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.5.0",
+        "@dolittle/contracts": "6.6.0-sam.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.5.0",
+        "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.common": "22.1.0",
         "@dolittle/sdk.dependencyinversion": "22.1.0",
         "@dolittle/sdk.execution": "22.1.0",

--- a/Source/events/EventTypeId.ts
+++ b/Source/events/EventTypeId.ts
@@ -20,13 +20,14 @@ export class EventTypeId extends ConceptAs<Guid, '@dolittle/sdk.events.EventType
     constructor(id: Guid) {
         super(id, '@dolittle/sdk.events.EventTypeId');
     }
+
     /**
      * Creates an {@link EventTypeId} from a {@link Guid} or a {@link string}.
-     * @param {Guid | string} id - The event type id.
-     * @returns {EventTypeId} The create event type id concept.
+     * @param {EventTypeIdLike} id - The event type id.
+     * @returns {EventTypeId} The created event type id concept.
      */
     static from(id: EventTypeIdLike): EventTypeId {
-        if (id instanceof EventTypeId) return id;
+        if (isEventTypeId(id)) return id;
         return new EventTypeId(Guid.as(id));
     }
 };

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.5.0",
+        "@dolittle/contracts": "6.6.0-sam.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.5.0",
+        "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.artifacts": "22.1.0",
         "@dolittle/sdk.execution": "22.1.0",
         "@dolittle/sdk.protobuf": "22.1.0",

--- a/Source/projections/Builders/CopyToMongoDBBuilder.ts
+++ b/Source/projections/Builders/CopyToMongoDBBuilder.ts
@@ -35,13 +35,13 @@ export class CopyToMongoDBBuilder<T> extends ICopyToMongoDBBuilder<T> {
     }
 
     /** @inheritdoc */
-    collection(collectionName: CollectionNameLike): ICopyToMongoDBBuilder<T> {
+    toCollection(collectionName: CollectionNameLike): ICopyToMongoDBBuilder<T> {
         this._collectionName = CollectionName.from(collectionName);
         return this;
     }
 
     /** @inheritdoc */
-    convert(field: ReadModelField<T>, to: Conversion): ICopyToMongoDBBuilder<T> {
+    withConversion(field: ReadModelField<T>, to: Conversion): ICopyToMongoDBBuilder<T> {
         this._conversions.set(ProjectionField.from(field), to);
         return this;
     }
@@ -51,10 +51,10 @@ export class CopyToMongoDBBuilder<T> extends ICopyToMongoDBBuilder<T> {
      * @param {IClientBuildResults} results - For keeping track of build results.
      * @returns {MongoDBCopies} The built {@link MongoDBCopies} specification.
      */
-    build(results: IClientBuildResults): MongoDBCopies {
+    build(results: IClientBuildResults): MongoDBCopies | undefined {
         if (this._collectionName === undefined) {
             results.addFailure(`The MongoDB collection name cannot be inferred for projection ${this._projectionId}`, 'Please specify the collection name explicitly');
-            return MongoDBCopies.default;
+            return undefined;
         }
 
         return new MongoDBCopies(true, this._collectionName, this._conversions);

--- a/Source/projections/Builders/CopyToMongoDBBuilder.ts
+++ b/Source/projections/Builders/CopyToMongoDBBuilder.ts
@@ -46,12 +46,6 @@ export class CopyToMongoDBBuilder<T> extends ICopyToMongoDBBuilder<T> {
         return this;
     }
 
-    /** @inheritdoc */
-    withoutDefaultConversions(): ICopyToMongoDBBuilder<T> {
-        // TODO: Implement discovery of conversions from decorators.
-        return this;
-    }
-
     /**
      * Builds the {@link MongoDBCopies} specification configured by this builder.
      * @param {IClientBuildResults} results - For keeping track of build results.

--- a/Source/projections/Builders/CopyToMongoDBBuilder.ts
+++ b/Source/projections/Builders/CopyToMongoDBBuilder.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ComplexValueMap } from '@dolittle/sdk.artifacts';
+import { IClientBuildResults } from '@dolittle/sdk.common';
+import { Constructor } from '@dolittle/types';
+
+import { ProjectionField } from '../Copies/ProjectionField';
+import { CollectionName, CollectionNameLike } from '../Copies/MongoDB/CollectionName';
+import { Conversion } from '../Copies/MongoDB/Conversion';
+import { MongoDBCopies } from '../Copies/MongoDB/MongoDBCopies';
+import { ProjectionId } from '../ProjectionId';
+import { ICopyToMongoDBBuilder } from './ICopyToMongoDBBuilder';
+import { ReadModelField } from './ReadModelField';
+
+/**
+ * Represents an implementation of {@link ICopyToMongoDBBuilder}.
+ * @template T The type of the projection read model.
+ */
+export class CopyToMongoDBBuilder<T> extends ICopyToMongoDBBuilder<T> {
+    private _collectionName?: CollectionName;
+    private readonly _conversions: Map<ProjectionField, Conversion> = new ComplexValueMap(ProjectionField, field => [field.value], 1);
+
+    /**
+     * Initialises a new instance of the {@link CopyToMongoDBBuilder} class.
+     * @param {ProjectionId} _projectionId - The unique identifier of the projection to build for.
+     * @param {Constructor<T> | T} _readModelTypeOrInstance - The read model type.
+     */
+    constructor(
+        private readonly _projectionId: ProjectionId,
+        private readonly _readModelTypeOrInstance: Constructor<T> | T,
+    ) {
+        super();
+        this.inferCollectionNameFromType();
+    }
+
+    /** @inheritdoc */
+    collection(collectionName: CollectionNameLike): ICopyToMongoDBBuilder<T> {
+        this._collectionName = CollectionName.from(collectionName);
+        return this;
+    }
+
+    /** @inheritdoc */
+    convert(field: ReadModelField<T>, to: Conversion): ICopyToMongoDBBuilder<T> {
+        this._conversions.set(ProjectionField.from(field), to);
+        return this;
+    }
+
+    /** @inheritdoc */
+    withoutDefaultConversions(): ICopyToMongoDBBuilder<T> {
+        // TODO: Implement discovery of conversions from decorators.
+        return this;
+    }
+
+    /**
+     * Builds the {@link MongoDBCopies} specification configured by this builder.
+     * @param {IClientBuildResults} results - For keeping track of build results.
+     * @returns {MongoDBCopies} The built {@link MongoDBCopies} specification.
+     */
+    build(results: IClientBuildResults): MongoDBCopies {
+        if (this._collectionName === undefined) {
+            results.addFailure(`The MongoDB collection name cannot be inferred for projection ${this._projectionId}`, 'Please specify the collection name explicitly');
+            return MongoDBCopies.default;
+        }
+
+        return new MongoDBCopies(true, this._collectionName, this._conversions);
+    }
+
+    private inferCollectionNameFromType() {
+        if (this._readModelTypeOrInstance instanceof Function) {
+            this._collectionName = CollectionName.from(this._readModelTypeOrInstance.name);
+        }
+    }
+}

--- a/Source/projections/Builders/CopyToMongoDBCallback.ts
+++ b/Source/projections/Builders/CopyToMongoDBCallback.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ICopyToMongoDBBuilder } from './ICopyToMongoDBBuilder';
+
+/**
+ * Defines the callback signature used for configuring read model copies to a MongoDB collection.
+ * @template T The type of the projection read model.
+ */
+export type CopyToMongoDBCallback<T> = (builder: ICopyToMongoDBBuilder<T>) => void;

--- a/Source/projections/Builders/ICopyToMongoDBBuilder.ts
+++ b/Source/projections/Builders/ICopyToMongoDBBuilder.ts
@@ -3,17 +3,7 @@
 
 import { CollectionNameLike } from '../Copies/MongoDB/CollectionName';
 import { Conversion } from '../Copies/MongoDB/Conversion';
-
-type RecursiveReadModelField<T, P extends string> =
-    T extends (infer U)[] ? RecursiveReadModelField<U, P> :
-    T extends object ? P | `${P}.${ReadModelField<T>}` :
-    P;
-
-type ReadModelField<T> = ({
-    [TKey in keyof T & string]:
-        T[TKey] extends Function ? never :
-        RecursiveReadModelField<T[TKey], `${TKey}`>;
-})[ keyof T & string];
+import { ReadModelField } from './ReadModelField';
 
 /**
  * Defines a builder for configuring read model copies to a MongoDB collection.

--- a/Source/projections/Builders/ICopyToMongoDBBuilder.ts
+++ b/Source/projections/Builders/ICopyToMongoDBBuilder.ts
@@ -24,10 +24,4 @@ export abstract class ICopyToMongoDBBuilder<T> {
      * @returns {ICopyToMongoDBBuilder<T>} - The builder for continuation.
      */
     abstract convert(field: ReadModelField<T>, to: Conversion): ICopyToMongoDBBuilder<T>;
-
-    /**
-     * Disables the use of default conversions specified with decorators on the read model.
-     * @returns {ICopyToMongoDBBuilder<T>} - The builder for continuation.
-     */
-    abstract withoutDefaultConversions(): ICopyToMongoDBBuilder<T>;
 }

--- a/Source/projections/Builders/ICopyToMongoDBBuilder.ts
+++ b/Source/projections/Builders/ICopyToMongoDBBuilder.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CollectionNameLike } from '../Copies/MongoDB/CollectionName';
+import { Conversion } from '../Copies/MongoDB/Conversion';
+
+type RecursiveReadModelField<T, P extends string> =
+    T extends (infer U)[] ? RecursiveReadModelField<U, P> :
+    T extends object ? P | `${P}.${ReadModelField<T>}` :
+    P;
+
+type ReadModelField<T> = ({
+    [TKey in keyof T & string]:
+        T[TKey] extends Function ? never :
+        RecursiveReadModelField<T[TKey], `${TKey}`>;
+})[ keyof T & string];
+
+/**
+ * Defines a builder for configuring read model copies to a MongoDB collection.
+ * @template T The type of the projection read model.
+ */
+export abstract class ICopyToMongoDBBuilder<T> {
+    /**
+     * Configures the collection name to store the read model copies in.
+     * @param {CollectionNameLike} collectionName - The collection name.
+     * @returns {ICopyToMongoDBBuilder<T>} - The builder for continuation.
+     */
+    abstract collection(collectionName: CollectionNameLike): ICopyToMongoDBBuilder<T>;
+
+    /**
+     * Configures a conversion for a field on the readmodel.
+     * @param {ReadModelField<T>} field - The field to convert.
+     * @param {Conversion} to - The conversion to apply.
+     * @returns {ICopyToMongoDBBuilder<T>} - The builder for continuation.
+     */
+    abstract convert(field: ReadModelField<T>, to: Conversion): ICopyToMongoDBBuilder<T>;
+
+    /**
+     * Disables the use of default conversions specified with decorators on the read model.
+     * @returns {ICopyToMongoDBBuilder<T>} - The builder for continuation.
+     */
+    abstract withoutDefaultConversions(): ICopyToMongoDBBuilder<T>;
+}

--- a/Source/projections/Builders/ICopyToMongoDBBuilder.ts
+++ b/Source/projections/Builders/ICopyToMongoDBBuilder.ts
@@ -15,7 +15,7 @@ export abstract class ICopyToMongoDBBuilder<T> {
      * @param {CollectionNameLike} collectionName - The collection name.
      * @returns {ICopyToMongoDBBuilder<T>} - The builder for continuation.
      */
-    abstract collection(collectionName: CollectionNameLike): ICopyToMongoDBBuilder<T>;
+    abstract toCollection(collectionName: CollectionNameLike): ICopyToMongoDBBuilder<T>;
 
     /**
      * Configures a conversion for a field on the readmodel.
@@ -23,5 +23,5 @@ export abstract class ICopyToMongoDBBuilder<T> {
      * @param {Conversion} to - The conversion to apply.
      * @returns {ICopyToMongoDBBuilder<T>} - The builder for continuation.
      */
-    abstract convert(field: ReadModelField<T>, to: Conversion): ICopyToMongoDBBuilder<T>;
+    abstract withConversion(field: ReadModelField<T>, to: Conversion): ICopyToMongoDBBuilder<T>;
 }

--- a/Source/projections/Builders/IProjectionBuilderForReadModel.ts
+++ b/Source/projections/Builders/IProjectionBuilderForReadModel.ts
@@ -9,6 +9,7 @@ import { EventType, EventTypeIdLike, ScopeId } from '@dolittle/sdk.events';
 
 import { ProjectionCallback } from '../ProjectionCallback';
 import { KeySelectorBuilderCallback } from './KeySelectorBuilderCallback';
+import { CopyToMongoDBCallback } from './CopyToMongoDBCallback';
 
 /**
  * Defines a builder for building a projection for a read model from method callbacks.
@@ -59,4 +60,11 @@ export abstract class IProjectionBuilderForReadModel<T> {
      * @returns {IProjectionBuilderForReadModel<T>} The builder for continuation.
      */
     abstract inScope(scopeId: ScopeId | Guid | string): IProjectionBuilderForReadModel<T>;
+
+    /**
+     * Configures the projection to write copies of read models to a MongoDB collection.
+     * @param {CopyToMongoDBCallback} [callback] - An optional callback to use to configure the read model copies.
+     * @returns {IProjectionBuilderForReadModel<T>} The builder for continuation.
+     */
+    abstract copyToMongoDB(callback?: CopyToMongoDBCallback<T>): IProjectionBuilderForReadModel<T>;
 }

--- a/Source/projections/Builders/ProjectionBuilderForReadModel.ts
+++ b/Source/projections/Builders/ProjectionBuilderForReadModel.ts
@@ -13,13 +13,13 @@ import { KeySelector } from '../KeySelector';
 import { Projection } from '../Projection';
 import { ProjectionCallback } from '../ProjectionCallback';
 import { ProjectionId } from '../ProjectionId';
+import { ProjectionModelId } from '../ProjectionModelId';
 import { IProjectionBuilderForReadModel } from './IProjectionBuilderForReadModel';
 import { KeySelectorBuilder } from './KeySelectorBuilder';
 import { KeySelectorBuilderCallback } from './KeySelectorBuilderCallback';
 import { OnMethodSpecification } from './OnMethodSpecification';
 import { TypeOrEventType } from './TypeOrEventType';
-import { ProjectionModelId } from '../ProjectionModelId';
-import { ProjectionBuilder } from '..';
+import { ProjectionBuilder } from './ProjectionBuilder';
 
 /**
  * Represents an implementation of {@link IProjectionBuilderForReadModel}.

--- a/Source/projections/Builders/ProjectionBuilderForReadModel.ts
+++ b/Source/projections/Builders/ProjectionBuilderForReadModel.ts
@@ -21,6 +21,7 @@ import { OnMethodSpecification } from './OnMethodSpecification';
 import { TypeOrEventType } from './TypeOrEventType';
 import { ProjectionBuilder } from './ProjectionBuilder';
 import { CopyToMongoDBCallback } from './CopyToMongoDBCallback';
+import { ProjectionCopies } from '../Copies/ProjectionCopies';
 
 /**
  * Represents an implementation of {@link IProjectionBuilderForReadModel}.
@@ -105,7 +106,9 @@ export class ProjectionBuilderForReadModel<T> extends IProjectionBuilderForReadM
             results.addFailure(`Failed to register projection ${this._projectionId}. Could not build projection`, 'Maybe it tries to handle the same type of event twice?');
             return;
         }
-        return new Projection<T>(this._projectionId, this._readModelTypeOrInstance, this._scopeId, events);
+        const copies = ProjectionCopies.default;
+        //TODO: Create copies.
+        return new Projection<T>(this._projectionId, this._readModelTypeOrInstance, this._scopeId, events, copies);
     }
 
     private tryAddOnMethods(

--- a/Source/projections/Builders/ProjectionBuilderForReadModel.ts
+++ b/Source/projections/Builders/ProjectionBuilderForReadModel.ts
@@ -112,6 +112,10 @@ export class ProjectionBuilderForReadModel<T> extends IProjectionBuilderForReadM
         }
 
         const copies = this.buildCopies(results);
+        if (copies === undefined) {
+            results.addFailure(`Failed to register projection ${this._projectionId}. Copies specification is not valid`);
+            return undefined;
+        }
 
         return new Projection<T>(this._projectionId, this._readModelTypeOrInstance, this._scopeId, events, copies);
     }
@@ -158,13 +162,19 @@ export class ProjectionBuilderForReadModel<T> extends IProjectionBuilderForReadM
         return eventType;
     }
 
-    private buildCopies(results: IClientBuildResults): ProjectionCopies {
+    private buildCopies(results: IClientBuildResults): ProjectionCopies | undefined {
+        const mongoDBCopies = this.buildMongoDBCopies(results);
+
+        if (mongoDBCopies === undefined) {
+            return undefined;
+        }
+
         return new ProjectionCopies(
-            this.buildMongoDBCopies(results),
+            mongoDBCopies,
         );
     }
 
-    private buildMongoDBCopies(results: IClientBuildResults): MongoDBCopies {
+    private buildMongoDBCopies(results: IClientBuildResults): MongoDBCopies | undefined {
         if (this._copyToMongoDBCallback === undefined) {
             return MongoDBCopies.default;
         }

--- a/Source/projections/Builders/ProjectionBuilderForReadModel.ts
+++ b/Source/projections/Builders/ProjectionBuilderForReadModel.ts
@@ -20,6 +20,7 @@ import { KeySelectorBuilderCallback } from './KeySelectorBuilderCallback';
 import { OnMethodSpecification } from './OnMethodSpecification';
 import { TypeOrEventType } from './TypeOrEventType';
 import { ProjectionBuilder } from './ProjectionBuilder';
+import { CopyToMongoDBCallback } from './CopyToMongoDBCallback';
 
 /**
  * Represents an implementation of {@link IProjectionBuilderForReadModel}.
@@ -78,6 +79,11 @@ export class ProjectionBuilderForReadModel<T> extends IProjectionBuilderForReadM
         this._modelBuilder.unbindIdentifierFromProcessorBuilder(this._modelId, this._parentBuilder);
         this._scopeId = ScopeId.from(scopeId);
         this._modelBuilder.bindIdentifierToProcessorBuilder(this._modelId, this._parentBuilder);
+        return this;
+    }
+
+    /** @inheritdoc */
+    copyToMongoDB(callback?: CopyToMongoDBCallback<T>): IProjectionBuilderForReadModel<T> {
         return this;
     }
 

--- a/Source/projections/Builders/ProjectionClassBuilder.ts
+++ b/Source/projections/Builders/ProjectionClassBuilder.ts
@@ -16,6 +16,7 @@ import { ProjectionCallback } from '../ProjectionCallback';
 import { OnDecoratedProjectionMethod } from './OnDecoratedProjectionMethod';
 import { getOnDecoratedMethods } from './onDecorator';
 import { ProjectionDecoratedType } from './ProjectionDecoratedType';
+import { ProjectionCopies } from '../Copies/ProjectionCopies';
 
 /**
  * Represents a builder for building a projection from a class.
@@ -54,7 +55,9 @@ export class ProjectionClassBuilder<T> implements IEquatable {
             results.addFailure(`Could not create projection ${this.type.type.name} because it contains invalid projection methods`, 'Maybe you have multiple @on methods handling the same event type?');
             return;
         }
-        return new Projection<T>(this.type.projectionId, this.type.type, this.type.scopeId, events);
+        const copies = ProjectionCopies.default;
+        //TODO: Create copies.
+        return new Projection<T>(this.type.projectionId, this.type.type, this.type.scopeId, events, copies);
     }
 
     private tryAddAllOnMethods(events: EventTypeMap<[ProjectionCallback<T>, KeySelector]>, type: Constructor<any>, eventTypes: IEventTypes): boolean {

--- a/Source/projections/Builders/ReadModelField.ts
+++ b/Source/projections/Builders/ReadModelField.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+type RecursiveReadModelField<T, P extends string> =
+    T extends (infer U)[] ? RecursiveReadModelField<U, P> :
+    T extends object ? P | `${P}.${ReadModelField<T>}` :
+    P;
+
+/**
+ * Defines the fields of a read model type.
+ */
+export type ReadModelField<T> = ({
+    [TKey in keyof T & string]:
+        T[TKey] extends Function ? never :
+        RecursiveReadModelField<T[TKey], `${TKey}`>;
+})[ keyof T & string];

--- a/Source/projections/Builders/_exports.ts
+++ b/Source/projections/Builders/_exports.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+export { CopyToMongoDBCallback } from './CopyToMongoDBCallback';
 export { CouldNotCreateInstanceOfProjection } from './CouldNotCreateInstanceOfProjection';
+export { ICopyToMongoDBBuilder } from './ICopyToMongoDBBuilder';
 export { IProjectionBuilder } from './IProjectionBuilder';
 export { IProjectionBuilderForReadModel } from './IProjectionBuilderForReadModel';
 export { IProjectionsBuilder } from './IProjectionsBuilder';

--- a/Source/projections/Builders/_exports.ts
+++ b/Source/projections/Builders/_exports.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+export { CopyToMongoDBBuilder } from './CopyToMongoDBBuilder';
 export { CopyToMongoDBCallback } from './CopyToMongoDBCallback';
 export { CouldNotCreateInstanceOfProjection } from './CouldNotCreateInstanceOfProjection';
 export { ICopyToMongoDBBuilder } from './ICopyToMongoDBBuilder';
@@ -23,4 +24,5 @@ export { ProjectionsBuilder } from './ProjectionsBuilder';
 export { ProjectionsBuilderCallback } from './ProjectionsBuilderCallback';
 export { ProjectionsModelBuilder } from './ProjectionsModelBuilder';
 export { ReadModelAlreadyDefinedForProjection } from './ReadModelAlreadyDefinedForProjection';
+export { ReadModelField } from './ReadModelField';
 export { TypeOrEventType } from './TypeOrEventType';

--- a/Source/projections/Copies/MongoDB/CollectionName.ts
+++ b/Source/projections/Copies/MongoDB/CollectionName.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ConceptAs, createIsConceptAsString } from '@dolittle/concepts';
+
+/**
+ * Defines the types that can be converted into a {@link CollectionName}.
+ */
+export type CollectionNameLike = string | CollectionName;
+
+/**
+ * Represents the name of a Collection in MongoDB.
+ */
+export class CollectionName extends ConceptAs<string, '@dolittle/sdk.projections.Copies.MongoDB.CollectionName'> {
+    /**
+     * Initialises a new instance of the {@link CollectionName} class.
+     * @param {string} name - The name of the collection.
+     */
+    constructor(name: string) {
+        super(name, '@dolittle/sdk.projections.Copies.MongoDB.CollectionName');
+    }
+
+    /**
+     * Creates a {@link CollectionName} from a {@link string}.
+     * @param {CollectionNameLike} name - The name of the collection.
+     * @returns {CollectionName} The created collection name concept.
+     */
+    static from(name: CollectionNameLike): CollectionName {
+        if (isCollectionName(name)) return name;
+        return new CollectionName(name);
+    }
+}
+
+/**
+ * Checks whether or not an object is an instance of {@link CollectionName}.
+ * @param {any} object - The object to check.
+ * @returns {boolean} True if the object is an {@link CollectionName}, false if not.
+ */
+export const isCollectionName = createIsConceptAsString(CollectionName, '@dolittle/sdk.projections.Copies.MongoDB.CollectionName');

--- a/Source/projections/Copies/MongoDB/CollectionName.ts
+++ b/Source/projections/Copies/MongoDB/CollectionName.ts
@@ -21,6 +21,13 @@ export class CollectionName extends ConceptAs<string, '@dolittle/sdk.projections
     }
 
     /**
+     * Gets the not set collection name.
+     */
+    static get notSet(): CollectionName {
+        return CollectionName.from('Not Set');
+    }
+
+    /**
      * Creates a {@link CollectionName} from a {@link string}.
      * @param {CollectionNameLike} name - The name of the collection.
      * @returns {CollectionName} The created collection name concept.

--- a/Source/projections/Copies/MongoDB/Conversion.ts
+++ b/Source/projections/Copies/MongoDB/Conversion.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Represents MongoDB read model field conversions.
+ */
+export enum Conversion {
+    /**
+     * Converts the field into a BSON DateTime.
+     */
+    DateTime = 1,
+
+    /**
+     * Converts the field into a BSON Timestamp.
+     */
+    Timestamp = 2,
+
+    /**
+     * Converts the field into a BSON Binary.
+     */
+    Binary = 3,
+}

--- a/Source/projections/Copies/MongoDB/MongoDBCopies.ts
+++ b/Source/projections/Copies/MongoDB/MongoDBCopies.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ProjectionField } from '../ProjectionField';
+import { CollectionName } from './CollectionName';
+import { Conversion } from './Conversion';
+
+/**
+ * Represents the specification of MongoDB read model copies to produce for a projection.
+ */
+export class MongoDBCopies {
+    /**
+     * Initialises a new instance of the {@link MongoDBCopies} class.
+     * @param {boolean} shouldCopyToMongoDB - A value indicating whether or not to produce read model copies to a MongoDB collection.
+     * @param {CollectionName} collectionName - The name of the collection to copy read models to.
+     * @param {ReadonlyMap<ProjectionField, Conversion>} conversions - The conversions to apply when copying read models.
+     */
+    constructor(
+        readonly shouldCopyToMongoDB: boolean,
+        readonly collectionName: CollectionName,
+        readonly conversions: ReadonlyMap<ProjectionField, Conversion>,
+    ) {}
+}

--- a/Source/projections/Copies/MongoDB/MongoDBCopies.ts
+++ b/Source/projections/Copies/MongoDB/MongoDBCopies.ts
@@ -20,4 +20,11 @@ export class MongoDBCopies {
         readonly collectionName: CollectionName,
         readonly conversions: ReadonlyMap<ProjectionField, Conversion>,
     ) {}
+
+    /**
+     * Gets the default {@link MongoDBCopies} specification, where no read model copies will be produced in MongoDB.
+     */
+    static get default(): MongoDBCopies {
+        return new MongoDBCopies(false, CollectionName.notSet, new Map());
+    }
 }

--- a/Source/projections/Copies/MongoDB/UnknownMongoDBConversion.ts
+++ b/Source/projections/Copies/MongoDB/UnknownMongoDBConversion.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Exception } from '@dolittle/rudiments';
+
+import { Conversion } from './Conversion';
+
+/**
+ * The exception that gets thrown when an unknown {@link Conversion} is specified.
+ */
+export class UnknownMongoDBConversion extends Exception {
+    /**
+     * Initialises a new instance of the {@link UnknownMongoDBConversion} class.
+     * @param {Conversion} conversion - The conversion that was specified.
+     */
+    constructor(conversion: Conversion) {
+        super(`The MongoDB field conversion type ${conversion} is unknown`);
+    }
+}

--- a/Source/projections/Copies/MongoDB/_exports.ts
+++ b/Source/projections/Copies/MongoDB/_exports.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { CollectionName, CollectionNameLike, isCollectionName } from './CollectionName';
+export { Conversion } from './Conversion';

--- a/Source/projections/Copies/MongoDB/_exports.ts
+++ b/Source/projections/Copies/MongoDB/_exports.ts
@@ -3,3 +3,5 @@
 
 export { CollectionName, CollectionNameLike, isCollectionName } from './CollectionName';
 export { Conversion } from './Conversion';
+export { MongoDBCopies } from './MongoDBCopies';
+export { UnknownMongoDBConversion } from './UnknownMongoDBConversion';

--- a/Source/projections/Copies/ProjectionCopies.ts
+++ b/Source/projections/Copies/ProjectionCopies.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { MongoDBCopies } from './MongoDB/MongoDBCopies';
+
+/**
+ * Represents the specification of read model copies to produce for a projection.
+ */
+export class ProjectionCopies {
+    /**
+     * Initialises a new instance of the {@link ProjectionCopies} class.
+     * @param {MongoDBCopies} mongoDB - The specification of MongoDB read model copies.
+     */
+    constructor(
+        readonly mongoDB: MongoDBCopies,
+    ) {}
+}

--- a/Source/projections/Copies/ProjectionCopies.ts
+++ b/Source/projections/Copies/ProjectionCopies.ts
@@ -14,4 +14,11 @@ export class ProjectionCopies {
     constructor(
         readonly mongoDB: MongoDBCopies,
     ) {}
+
+    /**
+     * Gets the default {@link ProjectionCopies} specification, where no read model copies will be produced.
+     */
+    static get default(): ProjectionCopies {
+        return new ProjectionCopies(MongoDBCopies.default);
+    }
 }

--- a/Source/projections/Copies/ProjectionField.ts
+++ b/Source/projections/Copies/ProjectionField.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ConceptAs, createIsConceptAsString } from '@dolittle/concepts';
+
+/**
+ * Defines the types that can be converted into a {@link ProjectionField}.
+ */
+export type ProjectionFieldLike = string | ProjectionField;
+
+/**
+ * Represents a field of a projection read model.
+ */
+export class ProjectionField extends ConceptAs<string, '@dolittle/sdk.projections.Copies.ProjectionField'> {
+    /**
+     * Initialises a new instance of the {@link ProjectionField} class.
+     * @param {string} field - The projection field.
+     */
+    constructor(field: string) {
+        super(field, '@dolittle/sdk.projections.Copies.ProjectionField');
+    }
+
+    /**
+     * Creates a {@link ProjectionField} from a {@link string}.
+     * @param {ProjectionFieldLike} field - The projection field.
+     * @returns {ProjectionField} The created projection field concept.
+     */
+    static from(field: ProjectionFieldLike): ProjectionField {
+        if (isProjectionField(field)) return field;
+        return new ProjectionField(field);
+    }
+}
+
+/**
+ * Checks whether or not an object is an instance of {@link ProjectionField}.
+ * @param {any} object - The object to check.
+ * @returns {boolean} True if the object is an {@link ProjectionField}, false if not.
+ */
+export const isProjectionField = createIsConceptAsString(ProjectionField, '@dolittle/sdk.projections.Copies.ProjectionField');

--- a/Source/projections/Copies/_exports.ts
+++ b/Source/projections/Copies/_exports.ts
@@ -4,3 +4,4 @@
 export * as MongoDB from './MongoDB/_exports';
 
 export { ProjectionField, ProjectionFieldLike, isProjectionField } from './ProjectionField';
+export { ProjectionCopies } from './ProjectionCopies';

--- a/Source/projections/Copies/_exports.ts
+++ b/Source/projections/Copies/_exports.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export * as MongoDB from './MongoDB/_exports';
+
+export { ProjectionField, ProjectionFieldLike, isProjectionField } from './ProjectionField';

--- a/Source/projections/IProjection.ts
+++ b/Source/projections/IProjection.ts
@@ -1,8 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { EventType, ScopeId } from '@dolittle/sdk.events';
 import { Constructor } from '@dolittle/types';
+
+import { EventType, ScopeId } from '@dolittle/sdk.events';
+
+import { ProjectionCopies } from './Copies/ProjectionCopies';
 import { DeleteReadModelInstance } from './DeleteReadModelInstance';
 import { EventSelector } from './EventSelector';
 import { ProjectionContext } from './ProjectionContext';
@@ -37,6 +40,11 @@ export abstract class IProjection<T> {
      * Gets the events used by the projection.
      */
     abstract readonly events: Iterable<EventSelector>;
+
+    /**
+     * Gets the specification of read model copies to produce for the projection.
+     */
+    abstract readonly copies: ProjectionCopies;
 
     /**
      * Handle an event and update a readmodel.

--- a/Source/projections/Projection.ts
+++ b/Source/projections/Projection.ts
@@ -3,7 +3,8 @@
 
 import { EventType, EventTypeMap, ScopeId } from '@dolittle/sdk.events';
 import { Constructor } from '@dolittle/types';
-import { ProjectionCopies } from '.';
+
+import { ProjectionCopies } from './Copies/ProjectionCopies';
 import { DeleteReadModelInstance } from './DeleteReadModelInstance';
 import { EventSelector } from './EventSelector';
 import { IProjection } from './IProjection';

--- a/Source/projections/Projection.ts
+++ b/Source/projections/Projection.ts
@@ -3,6 +3,7 @@
 
 import { EventType, EventTypeMap, ScopeId } from '@dolittle/sdk.events';
 import { Constructor } from '@dolittle/types';
+import { ProjectionCopies } from '.';
 import { DeleteReadModelInstance } from './DeleteReadModelInstance';
 import { EventSelector } from './EventSelector';
 import { IProjection } from './IProjection';
@@ -29,12 +30,14 @@ export class Projection<T> extends IProjection<T> {
      * @param {Constructor<T>|T} readModelTypeOrInstance - The read model type or instance produced by the projection.
      * @param {ScopeId} scopeId - The identifier of the scope the projection is in.
      * @param {EventTypeMap<[ProjectionCallback<any>, KeySelector]>} _eventMap - The events with respective callbacks and keyselectors used by the projection.
+     * @param {ProjectionCopies} copies - The read model copies specification for the projection.
      */
     constructor(
         readonly projectionId: ProjectionId,
         readonly readModelTypeOrInstance: Constructor<T> | T,
         readonly scopeId: ScopeId,
-        private readonly _eventMap: EventTypeMap<[ProjectionCallback<any>, KeySelector]>
+        private readonly _eventMap: EventTypeMap<[ProjectionCallback<any>, KeySelector]>,
+        readonly copies: ProjectionCopies,
     ) {
         super();
 

--- a/Source/projections/index.ts
+++ b/Source/projections/index.ts
@@ -34,6 +34,7 @@ export {
     ProjectionField,
     ProjectionFieldLike,
     isProjectionField,
+    ProjectionCopies,
 } from './Copies/_exports';
 
 export {
@@ -41,6 +42,8 @@ export {
     CollectionNameLike as MongoDBCollectionNameLike,
     isCollectionName as isMongoDBCollectionName,
     Conversion as MongoDBConversion,
+    MongoDBCopies,
+    UnknownMongoDBConversion,
 } from './Copies/MongoDB/_exports';
 
 export {

--- a/Source/projections/index.ts
+++ b/Source/projections/index.ts
@@ -4,6 +4,8 @@
 export * from './_exports';
 
 export {
+    CopyToMongoDBBuilder,
+    CopyToMongoDBCallback,
     CouldNotCreateInstanceOfProjection,
     IProjectionBuilder,
     IProjectionBuilderForReadModel,
@@ -27,6 +29,7 @@ export {
     ProjectionsBuilderCallback,
     ProjectionsModelBuilder,
     ReadModelAlreadyDefinedForProjection,
+    ReadModelField,
     TypeOrEventType,
 } from './Builders/_exports';
 

--- a/Source/projections/index.ts
+++ b/Source/projections/index.ts
@@ -31,6 +31,19 @@ export {
 } from './Builders/_exports';
 
 export {
+    ProjectionField,
+    ProjectionFieldLike,
+    isProjectionField,
+} from './Copies/_exports';
+
+export {
+    CollectionName as MongoDBCollectionName,
+    CollectionNameLike as MongoDBCollectionNameLike,
+    isCollectionName as isMongoDBCollectionName,
+    Conversion as MongoDBConversion,
+} from './Copies/MongoDB/_exports';
+
+export {
     CurrentState,
     CurrentStateType,
     FailedToGetProjection,

--- a/Source/projections/package.json
+++ b/Source/projections/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.5.0",
+        "@dolittle/contracts": "6.6.0-sam.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.5.0",
+        "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.artifacts": "22.1.0",
         "@dolittle/sdk.common": "22.1.0",
         "@dolittle/sdk.dependencyinversion": "22.1.0",

--- a/Source/protobuf/package.json
+++ b/Source/protobuf/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.5.0",
+        "@dolittle/contracts": "6.6.0-sam.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.artifacts": "22.1.0",
         "@dolittle/sdk.execution": "22.1.0"

--- a/Source/resources/package.json
+++ b/Source/resources/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.5.0",
+        "@dolittle/contracts": "6.6.0-sam.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.5.0",
+        "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.execution": "22.1.0",
         "@dolittle/sdk.protobuf": "22.1.0",
         "@dolittle/sdk.resilience": "22.1.0",

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -45,7 +45,7 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/runtime.contracts": "6.5.0",
+        "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.aggregates": "22.1.0",
         "@dolittle/sdk.artifacts": "22.1.0",
         "@dolittle/sdk.common": "22.1.0",

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.5.0",
+        "@dolittle/contracts": "6.6.0-sam.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.common": "22.1.0",
         "@dolittle/sdk.dependencyinversion": "22.1.0",

--- a/Source/tenancy/package.json
+++ b/Source/tenancy/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.5.0",
+        "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.execution": "22.1.0",
         "@dolittle/sdk.protobuf": "22.1.0",
         "@dolittle/sdk.resilience": "22.1.0",


### PR DESCRIPTION
## Summary

Implements the explicit builder API for specifying read model copies to MongoDB for a projection. This implementation should send over the specification to the Runtime.

Todo:
- Decorators for specifying copies and conversions on projection classes
- Detecting decorators when registering projections from types