### PR TITLE
Extend MongoDB Db.collection method

### DIFF
--- a/Source/resources/MongoDB/DbExtensions.ts
+++ b/Source/resources/MongoDB/DbExtensions.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// import { Constructor } from '@dolittle/types';
+// import { Collection, CollectionOptions, Db as mongodbDb, DbOptions, Document, MongoClient } from 'mongodb';
+
+import { Constructor } from '@dolittle/types';
+import { Collection, CollectionOptions, Db, Document } from 'mongodb';
+
+import { getDecoratedCopyProjectionToMongoDB, isDecoratedCopyProjectionToMongoDB } from '@dolittle/sdk.projections';
+
+declare module 'mongodb' {
+    interface Db {
+        /**
+         * Returns a reference to a MongoDB Collection. If it does not exist it will be created implicitly.
+         *
+         * @param name - The collection name we wish to access.
+         * @returns Return the new Collection instance.
+         */
+        collection<TSchema extends Document>(type: Constructor<TSchema>, options?: CollectionOptions): Collection<TSchema>;
+    }
+}
+
+const originalCollectionMethod = Db.prototype.collection;
+
+Db.prototype.collection = function<TSchema extends Document>(typeOrName: Constructor<TSchema> | string, options?: CollectionOptions): Collection<TSchema> {
+    let collectionName = typeof typeOrName === 'string' ? typeOrName : typeOrName.name;
+
+    if (typeOrName instanceof Function && isDecoratedCopyProjectionToMongoDB(typeOrName)) {
+        const decorator = getDecoratedCopyProjectionToMongoDB(typeOrName);
+        collectionName = decorator.collection.value;
+    }
+
+    return originalCollectionMethod(collectionName, options);
+};

--- a/Source/resources/MongoDB/DbExtensions.ts
+++ b/Source/resources/MongoDB/DbExtensions.ts
@@ -21,7 +21,8 @@ declare module 'mongodb' {
     }
 }
 
-const originalCollectionMethod = Db.prototype.collection;
+type OriginalCollectionSignature = (name: string, options?: CollectionOptions) => Collection;
+const originalCollectionMethod: OriginalCollectionSignature = Db.prototype.collection;
 
 Db.prototype.collection = function<TSchema extends Document>(typeOrName: Constructor<TSchema> | string, options?: CollectionOptions): Collection<TSchema> {
     let collectionName = typeof typeOrName === 'string' ? typeOrName : typeOrName.name;
@@ -31,5 +32,5 @@ Db.prototype.collection = function<TSchema extends Document>(typeOrName: Constru
         collectionName = decorator.collection.value;
     }
 
-    return originalCollectionMethod(collectionName, options);
+    return originalCollectionMethod.call(this, collectionName, options) as any;
 };

--- a/Source/resources/MongoDB/_exports.ts
+++ b/Source/resources/MongoDB/_exports.ts
@@ -2,5 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export * as Internal from './Internal/_exports';
+
 export { IMongoDBResource } from './IMongoDBResource';
 export { DatabaseSettingsCallback } from './DatabaseSettingsCallback';
+
+import './DbExtensions';

--- a/Source/resources/package.json
+++ b/Source/resources/package.json
@@ -49,6 +49,7 @@
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/runtime.contracts": "6.6.0-sam.0",
         "@dolittle/sdk.execution": "22.2.0-sam.1",
+        "@dolittle/sdk.projections": "22.2.0-sam.1",
         "@dolittle/sdk.protobuf": "22.2.0-sam.1",
         "@dolittle/sdk.resilience": "22.2.0-sam.1",
         "@dolittle/sdk.services": "22.2.0-sam.1",

--- a/Source/resources/tsconfig.json
+++ b/Source/resources/tsconfig.json
@@ -11,6 +11,7 @@
         { "path": "../execution" },
         { "path": "../resilience" },
         { "path": "../services" },
+        { "path": "../projections" },
         { "path": "../protobuf" },
     ]
 }


### PR DESCRIPTION
## Summary

Extends the `Db.collection` method with an overload to more easily get the collection for a Projection read model type.