### PR TITLE
Validate collection names, upgrade contracts and add specs.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
         '@typescript-eslint/unified-signatures': 'off',
         'import/no-extraneous-dependencies': 'off',
         'eol-last': 'error',
-        'no-multiple-empty-lines': ['error', { 'max': 1, 'maxEOF': 0 }],
+        'no-multiple-empty-lines': ['error', {'max': 1, 'maxEOF': 0 }],
         'header/header': [
             2,
             'line',
@@ -61,7 +61,7 @@ module.exports = {
 		        'MethodDefinition[accessibility!="private"][value.type="FunctionExpression"]:not(MethodDefinition[value.type="TSEmptyBodyFunctionExpression"] + MethodDefinition[value.type="FunctionExpression"])',
             ]
         }],
-        
+
         'jsdoc/require-returns': ['error', {
             'contexts': [
                 'ArrowFunctionExpression',

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ Samples/**/data
 Source/**/Distribution
 Samples/**/Distribution
 Source/**/README.md
+
+.idea

--- a/Source/artifacts/package.json
+++ b/Source/artifacts/package.json
@@ -47,7 +47,7 @@
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/types": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.2"
+        "@dolittle/runtime.contracts": "6.6.0-sam.3"
     },
     "devDependencies": {
         "@types/is-natural-number": "^4.0.0"

--- a/Source/embeddings/package.json
+++ b/Source/embeddings/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.2",
+        "@dolittle/contracts": "6.6.0-sam.3",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.2",
+        "@dolittle/runtime.contracts": "6.6.0-sam.3",
         "@dolittle/sdk.artifacts": "22.2.0-sam.3",
         "@dolittle/sdk.common": "22.2.0-sam.3",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.3",

--- a/Source/eventHorizon/package.json
+++ b/Source/eventHorizon/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.2",
+        "@dolittle/runtime.contracts": "6.6.0-sam.3",
         "@dolittle/sdk.events": "22.2.0-sam.3",
         "@dolittle/sdk.execution": "22.2.0-sam.3",
         "@dolittle/sdk.protobuf": "22.2.0-sam.3",

--- a/Source/events.filtering/package.json
+++ b/Source/events.filtering/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.2",
+        "@dolittle/contracts": "6.6.0-sam.3",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.2",
+        "@dolittle/runtime.contracts": "6.6.0-sam.3",
         "@dolittle/sdk.common": "22.2.0-sam.3",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.3",
         "@dolittle/sdk.events": "22.2.0-sam.3",

--- a/Source/events.handling/package.json
+++ b/Source/events.handling/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.2",
+        "@dolittle/contracts": "6.6.0-sam.3",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.2",
+        "@dolittle/runtime.contracts": "6.6.0-sam.3",
         "@dolittle/sdk.artifacts": "22.2.0-sam.3",
         "@dolittle/sdk.common": "22.2.0-sam.3",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.3",

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.2",
+        "@dolittle/contracts": "6.6.0-sam.3",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.2",
+        "@dolittle/runtime.contracts": "6.6.0-sam.3",
         "@dolittle/sdk.common": "22.2.0-sam.3",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.3",
         "@dolittle/sdk.execution": "22.2.0-sam.3",

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.2",
+        "@dolittle/contracts": "6.6.0-sam.3",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.2",
+        "@dolittle/runtime.contracts": "6.6.0-sam.3",
         "@dolittle/sdk.artifacts": "22.2.0-sam.3",
         "@dolittle/sdk.execution": "22.2.0-sam.3",
         "@dolittle/sdk.protobuf": "22.2.0-sam.3",

--- a/Source/projections/Builders/Copies/CopyToMongoDBBuilder.ts
+++ b/Source/projections/Builders/Copies/CopyToMongoDBBuilder.ts
@@ -59,6 +59,12 @@ export class CopyToMongoDBBuilder<T> extends ICopyToMongoDBBuilder<T> {
             return undefined;
         }
 
+        const [collectionNameIsValid, collectionNameValidationError] = this._collectionName.isValid();
+        if (!collectionNameIsValid) {
+            results.addFailure(`Cannot create MongoDB read model copies. ${collectionNameValidationError?.message}`);
+            return undefined;
+        }
+
         return new MongoDBCopies(true, this._collectionName, this.buildPropertyConversions());
     }
 

--- a/Source/projections/Builders/for_ProjectionBuilderForReadModel/when_building/with_copies_to_mongodb/and_specifying_convresion_multiple_times.ts
+++ b/Source/projections/Builders/for_ProjectionBuilderForReadModel/when_building/with_copies_to_mongodb/and_specifying_convresion_multiple_times.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+import { stubInterface } from 'ts-sinon';
+
+import { IEventTypes, ScopeId } from '@dolittle/sdk.events';
+import { IClientBuildResults, IModelBuilder } from '@dolittle/sdk.common';
+
+import { ProjectionId } from '../../../../ProjectionId';
+import { ProjectionBuilder } from '../../../ProjectionBuilder';
+import { ProjectionBuilderForReadModel } from '../../../ProjectionBuilderForReadModel';
+import { Conversion } from '../../../../Copies/MongoDB/Conversion';
+
+class Projection {
+    dateProperty: Date[] = [];
+}
+
+describeThis(__filename, () => {
+
+    const model_builder = stubInterface<IModelBuilder>();
+    const parent_builder = stubInterface<ProjectionBuilder>();
+
+    const builder = new ProjectionBuilderForReadModel(
+        ProjectionId.from('2640b8db-0391-4f99-ae3c-093ed191b00a'),
+        Projection,
+        ScopeId.from('87655996-d359-483e-a075-c7d833c4e572'),
+        model_builder,
+        parent_builder);
+
+    builder.on('cf566852-1a29-4f96-ba54-568c88e4a0e6', _ => _.keyFromEventSource(), _ => _);
+
+    builder.copyToMongoDB(_ => _
+        .withConversion('dateProperty', Conversion.Guid)
+        .withConversion('dateProperty', Conversion.GuidAsString)
+        .withConversion('dateProperty', Conversion.Date)
+    );
+
+    const event_types = stubInterface<IEventTypes>();
+    const build_results = stubInterface<IClientBuildResults>();
+
+    const result = builder.build(event_types, build_results);
+
+    it('should return a projection', () => result!.should.not.be.undefined);
+    it('should set copy to MongoDB', () => result?.copies.mongoDB.shouldCopyToMongoDB.should.be.true);
+    it('should copy to a collection with the same name as the class', () => result?.copies.mongoDB.collectionName.value.should.equal(Projection.name));
+    it('should keep only the last conversion', () => result?.copies.mongoDB.conversions[0].convertTo.should.equal(Conversion.Date));
+});

--- a/Source/projections/Builders/for_ProjectionBuilderForReadModel/when_building/with_copies_to_mongodb/with_conversions.ts
+++ b/Source/projections/Builders/for_ProjectionBuilderForReadModel/when_building/with_copies_to_mongodb/with_conversions.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+import { stubInterface } from 'ts-sinon';
+
+import { IEventTypes, ScopeId } from '@dolittle/sdk.events';
+import { IClientBuildResults, IModelBuilder } from '@dolittle/sdk.common';
+
+import { ProjectionId } from '../../../../ProjectionId';
+import { ProjectionBuilder } from '../../../ProjectionBuilder';
+import { ProjectionBuilderForReadModel } from '../../../ProjectionBuilderForReadModel';
+import { Conversion } from '../../../../Copies/MongoDB/Conversion';
+import { PropertyConversion } from '../../../../Copies/MongoDB/PropertyConversion';
+import { ProjectionProperty } from '../../../../Copies/ProjectionProperty';
+
+describeThis(__filename, () => {
+
+    const model_builder = stubInterface<IModelBuilder>();
+    const parent_builder = stubInterface<ProjectionBuilder>();
+
+    const builder = new ProjectionBuilderForReadModel(
+        ProjectionId.from('2640b8db-0391-4f99-ae3c-093ed191b00a'),
+        {
+            dateProperty: new Date(),
+            dateArrayProperty: [ new Date() ],
+            nested: {
+                guidStringProperty: '',
+            }
+        },
+        ScopeId.from('87655996-d359-483e-a075-c7d833c4e572'),
+        model_builder,
+        parent_builder);
+
+    builder.on('cf566852-1a29-4f96-ba54-568c88e4a0e6', _ => _.keyFromEventSource(), _ => _);
+
+    builder.copyToMongoDB(_ => _
+        .toCollection('collection-name')
+        .withConversion('dateProperty', Conversion.Date)
+        .withConversion('dateArrayProperty', Conversion.Date)
+        .withConversion('nested.guidStringProperty', Conversion.Guid)
+    );
+
+    const event_types = stubInterface<IEventTypes>();
+    const build_results = stubInterface<IClientBuildResults>();
+
+    const result = builder.build(event_types, build_results);
+
+    it('should return a projection', () => result!.should.not.be.undefined);
+    it('should set copy to MongoDB', () => result?.copies.mongoDB.shouldCopyToMongoDB.should.be.true);
+    it('should copy to a collection with the given name', () => result?.copies.mongoDB.collectionName.value.should.equal('collection-name'));
+    it('should have all the conversions', () => result?.copies.mongoDB.conversions.should.have.deep.members([
+        new PropertyConversion(
+            ProjectionProperty.from('dateProperty'),
+            Conversion.Date,
+            false,
+            ProjectionProperty.from(''),
+            []),
+        new PropertyConversion(
+            ProjectionProperty.from('dateArrayProperty'),
+            Conversion.Date,
+            false,
+            ProjectionProperty.from(''),
+            []),
+        new PropertyConversion(
+            ProjectionProperty.from('nested'),
+            Conversion.None,
+            false,
+            ProjectionProperty.from(''),
+            [
+                new PropertyConversion(
+                    ProjectionProperty.from('guidStringProperty'),
+                    Conversion.Guid,
+                    false,
+                    ProjectionProperty.from(''),
+                    []),
+            ]),
+    ]));
+});

--- a/Source/projections/Builders/for_ProjectionBuilderForReadModel/when_building/with_copies_to_mongodb/with_copy_to_mongodb.ts
+++ b/Source/projections/Builders/for_ProjectionBuilderForReadModel/when_building/with_copies_to_mongodb/with_copy_to_mongodb.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+import { stubInterface } from 'ts-sinon';
+
+import { IEventTypes, ScopeId } from '@dolittle/sdk.events';
+import { IClientBuildResults, IModelBuilder } from '@dolittle/sdk.common';
+
+import { ProjectionId } from '../../../../ProjectionId';
+import { ProjectionBuilder } from '../../../ProjectionBuilder';
+import { ProjectionBuilderForReadModel } from '../../../ProjectionBuilderForReadModel';
+
+class Projection {}
+
+describeThis(__filename, () => {
+
+    const model_builder = stubInterface<IModelBuilder>();
+    const parent_builder = stubInterface<ProjectionBuilder>();
+
+    const builder = new ProjectionBuilderForReadModel(
+        ProjectionId.from('2640b8db-0391-4f99-ae3c-093ed191b00a'),
+        Projection,
+        ScopeId.from('87655996-d359-483e-a075-c7d833c4e572'),
+        model_builder,
+        parent_builder);
+
+    builder.on('cf566852-1a29-4f96-ba54-568c88e4a0e6', _ => _.keyFromEventSource(), _ => _);
+
+    builder.copyToMongoDB();
+
+    const event_types = stubInterface<IEventTypes>();
+    const build_results = stubInterface<IClientBuildResults>();
+
+    const result = builder.build(event_types, build_results);
+
+    it('should return a projection', () => result!.should.not.be.undefined);
+    it('should set copy to MongoDB', () => result?.copies.mongoDB.shouldCopyToMongoDB.should.be.true);
+    it('should copy to a collection with the same name as the class', () => result?.copies.mongoDB.collectionName.value.should.equal(Projection.name));
+    it('should not have any conversions', () => result?.copies.mongoDB.conversions.should.be.empty);
+});

--- a/Source/projections/Builders/for_ProjectionBuilderForReadModel/when_building/with_copies_to_mongodb/with_explicit_collection_name.ts
+++ b/Source/projections/Builders/for_ProjectionBuilderForReadModel/when_building/with_copies_to_mongodb/with_explicit_collection_name.ts
@@ -5,27 +5,31 @@ import { describeThis } from '@dolittle/typescript.testing';
 import { stubInterface } from 'ts-sinon';
 
 import { IEventTypes, ScopeId } from '@dolittle/sdk.events';
-import { IClientBuildResults } from '@dolittle/sdk.common';
+import { IClientBuildResults, IModelBuilder } from '@dolittle/sdk.common';
 
 import { ProjectionId } from '../../../../ProjectionId';
-import { copyProjectionToMongoDB } from '../../../Copies/copyProjectionToMongoDBDecorator';
-import { on } from '../../../onDecorator';
-import { ProjectionDecoratedType } from '../../../ProjectionDecoratedType';
-import { ProjectionClassBuilder } from '../../../ProjectionClassBuilder';
+import { ProjectionBuilder } from '../../../ProjectionBuilder';
+import { ProjectionBuilderForReadModel } from '../../../ProjectionBuilderForReadModel';
 
-@copyProjectionToMongoDB('collection-name')
-class Projection {
-    @on('32e2aaca-2374-42f0-bcb5-7fb19501e3da', _ => _.keyFromEventSource())
-    on() {}
-}
+class Projection {}
 
 describeThis(__filename, () => {
-    const decoratedType = new ProjectionDecoratedType(
-        ProjectionId.from('53cad890-5b8a-4146-acce-29dc2dc8c43e'),
-        ScopeId.from('28f6c232-cc11-493b-b032-398a5e651617'),
-        Projection);
 
-    const builder = new ProjectionClassBuilder(decoratedType);
+    const model_builder = stubInterface<IModelBuilder>();
+    const parent_builder = stubInterface<ProjectionBuilder>();
+
+    const builder = new ProjectionBuilderForReadModel(
+        ProjectionId.from('2640b8db-0391-4f99-ae3c-093ed191b00a'),
+        Projection,
+        ScopeId.from('87655996-d359-483e-a075-c7d833c4e572'),
+        model_builder,
+        parent_builder);
+
+    builder.on('cf566852-1a29-4f96-ba54-568c88e4a0e6', _ => _.keyFromEventSource(), _ => _);
+
+    builder.copyToMongoDB(_ => _
+        .toCollection('collection-name')
+    );
 
     const event_types = stubInterface<IEventTypes>();
     const build_results = stubInterface<IClientBuildResults>();

--- a/Source/projections/Builders/for_ProjectionBuilderForReadModel/when_building/with_copies_to_mongodb/without_calling_copyToMongoDB.ts
+++ b/Source/projections/Builders/for_ProjectionBuilderForReadModel/when_building/with_copies_to_mongodb/without_calling_copyToMongoDB.ts
@@ -5,25 +5,25 @@ import { describeThis } from '@dolittle/typescript.testing';
 import { stubInterface } from 'ts-sinon';
 
 import { IEventTypes, ScopeId } from '@dolittle/sdk.events';
-import { IClientBuildResults } from '@dolittle/sdk.common';
+import { IClientBuildResults, IModelBuilder } from '@dolittle/sdk.common';
 
 import { ProjectionId } from '../../../../ProjectionId';
-import { on } from '../../../onDecorator';
-import { ProjectionDecoratedType } from '../../../ProjectionDecoratedType';
-import { ProjectionClassBuilder } from '../../../ProjectionClassBuilder';
-
-class Projection {
-    @on('32e2aaca-2374-42f0-bcb5-7fb19501e3da', _ => _.keyFromEventSource())
-    on() {}
-}
+import { ProjectionBuilder } from '../../../ProjectionBuilder';
+import { ProjectionBuilderForReadModel } from '../../../ProjectionBuilderForReadModel';
 
 describeThis(__filename, () => {
-    const decoratedType = new ProjectionDecoratedType(
-        ProjectionId.from('53cad890-5b8a-4146-acce-29dc2dc8c43e'),
-        ScopeId.from('28f6c232-cc11-493b-b032-398a5e651617'),
-        Projection);
 
-    const builder = new ProjectionClassBuilder(decoratedType);
+    const model_builder = stubInterface<IModelBuilder>();
+    const parent_builder = stubInterface<ProjectionBuilder>();
+
+    const builder = new ProjectionBuilderForReadModel(
+        ProjectionId.from('2640b8db-0391-4f99-ae3c-093ed191b00a'),
+        {},
+        ScopeId.from('87655996-d359-483e-a075-c7d833c4e572'),
+        model_builder,
+        parent_builder);
+
+    builder.on('cf566852-1a29-4f96-ba54-568c88e4a0e6', _ => _.keyFromEventSource(), _ => _);
 
     const event_types = stubInterface<IEventTypes>();
     const build_results = stubInterface<IClientBuildResults>();

--- a/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_conversions.ts
+++ b/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_conversions.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+import { stubInterface } from 'ts-sinon';
+
+import { IEventTypes, ScopeId } from '@dolittle/sdk.events';
+import { IClientBuildResults } from '@dolittle/sdk.common';
+
+import { ProjectionId } from '../../../../ProjectionId';
+import { copyProjectionToMongoDB } from '../../../Copies/copyProjectionToMongoDBDecorator';
+import { convertToMongoDB } from '../../../Copies/convertToMongoDBDecorator';
+import { ProjectionProperty } from '../../../../Copies/ProjectionProperty';
+import { Conversion } from '../../../../Copies/MongoDB/Conversion';
+import { PropertyConversion } from '../../../../Copies/MongoDB/PropertyConversion';
+import { on } from '../../../onDecorator';
+import { ProjectionDecoratedType } from '../../../ProjectionDecoratedType';
+import { ProjectionClassBuilder } from '../../../ProjectionClassBuilder';
+
+@copyProjectionToMongoDB()
+class Projection {
+
+    @convertToMongoDB(Conversion.Date)
+    dateProperty: Date = new Date();
+
+    @convertToMongoDB(Conversion.Date)
+    dateArrayProperty: Date[] = [];
+
+    @convertToMongoDB(Conversion.Guid)
+    stringGuidProperty: string = '';
+
+    @on('32e2aaca-2374-42f0-bcb5-7fb19501e3da', _ => _.keyFromEventSource())
+    on() {}
+}
+
+describeThis(__filename, () => {
+    const decoratedType = new ProjectionDecoratedType(
+        ProjectionId.from('53cad890-5b8a-4146-acce-29dc2dc8c43e'),
+        ScopeId.from('28f6c232-cc11-493b-b032-398a5e651617'),
+        Projection);
+
+    const builder = new ProjectionClassBuilder(decoratedType);
+
+    const event_types = stubInterface<IEventTypes>();
+    const build_results = stubInterface<IClientBuildResults>();
+
+    const result = builder.build(event_types, build_results);
+
+    it('should return a projection', () => result!.should.not.be.undefined);
+    it('should set copy to MongoDB', () => result?.copies.mongoDB.shouldCopyToMongoDB.should.be.true);
+    it('should copy to a collection with the same name as the class', () => result?.copies.mongoDB.collectionName.value.should.equal(Projection.name));
+    it('should have all the conversions', () => result?.copies.mongoDB.conversions.should.have.deep.members([
+        new PropertyConversion(
+            ProjectionProperty.from('dateProperty'),
+            Conversion.Date,
+            false,
+            ProjectionProperty.from(''),
+            []),
+        new PropertyConversion(
+            ProjectionProperty.from('dateArrayProperty'),
+            Conversion.Date,
+            false,
+            ProjectionProperty.from(''),
+            []),
+        new PropertyConversion(
+            ProjectionProperty.from('stringGuidProperty'),
+            Conversion.Guid,
+            false,
+            ProjectionProperty.from(''),
+            []),
+    ]));
+});

--- a/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_copy_to_mongodb.ts
+++ b/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_copy_to_mongodb.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+import { stubInterface } from 'ts-sinon';
+
+import { IEventTypes, ScopeId } from '@dolittle/sdk.events';
+import { IClientBuildResults } from '@dolittle/sdk.common';
+
+import { ProjectionId } from '../../../../ProjectionId';
+import { copyProjectionToMongoDB } from '../../../Copies/copyProjectionToMongoDBDecorator';
+import { on } from '../../../onDecorator';
+import { ProjectionDecoratedType } from '../../../ProjectionDecoratedType';
+import { ProjectionClassBuilder } from '../../../ProjectionClassBuilder';
+
+@copyProjectionToMongoDB()
+class Projection {
+    @on('32e2aaca-2374-42f0-bcb5-7fb19501e3da', _ => _.keyFromEventSource())
+    on() {}
+}
+
+describeThis(__filename, () => {
+    const decoratedType = new ProjectionDecoratedType(
+        ProjectionId.from('53cad890-5b8a-4146-acce-29dc2dc8c43e'),
+        ScopeId.from('28f6c232-cc11-493b-b032-398a5e651617'),
+        Projection);
+
+    const builder = new ProjectionClassBuilder(decoratedType);
+
+    const event_types = stubInterface<IEventTypes>();
+    const build_results = stubInterface<IClientBuildResults>();
+
+    const result = builder.build(event_types, build_results);
+
+    it('should return a projection', () => result!.should.not.be.undefined);
+    it('should set copy to MongoDB', () => result?.copies.mongoDB.shouldCopyToMongoDB.should.be.true);
+    it('should copy to a collection with the same name as the class', () => result?.copies.mongoDB.collectionName.value.should.equal(Projection.name));
+    it('should not have any conversions', () => result?.copies.mongoDB.conversions.should.be.empty);
+});

--- a/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_explicit_collection_name.ts
+++ b/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_explicit_collection_name.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+import { stubInterface } from 'ts-sinon';
+
+import { IEventTypes, ScopeId } from '@dolittle/sdk.events';
+import { IClientBuildResults } from '@dolittle/sdk.common';
+
+import { ProjectionId } from '../../../../ProjectionId';
+import { copyProjectionToMongoDB } from '../../../Copies/copyProjectionToMongoDBDecorator';
+import { on } from '../../../onDecorator';
+import { ProjectionDecoratedType } from '../../../ProjectionDecoratedType';
+import { ProjectionClassBuilder } from '../../../ProjectionClassBuilder';
+
+@copyProjectionToMongoDB('collection-name')
+class Projection {
+    @on('32e2aaca-2374-42f0-bcb5-7fb19501e3da', _ => _.keyFromEventSource())
+    on() {}
+}
+
+describeThis(__filename, () => {
+    const decoratedType = new ProjectionDecoratedType(
+        ProjectionId.from('53cad890-5b8a-4146-acce-29dc2dc8c43e'),
+        ScopeId.from('28f6c232-cc11-493b-b032-398a5e651617'),
+        Projection);
+
+    const builder = new ProjectionClassBuilder(decoratedType);
+
+    const event_types = stubInterface<IEventTypes>();
+    const build_results = stubInterface<IClientBuildResults>();
+
+    const result = builder.build(event_types, build_results);
+
+    it('should return a projection', () => result!.should.not.be.undefined);
+    it('should set copy to MongoDB', () => result?.copies.mongoDB.shouldCopyToMongoDB.should.be.true);
+    it('should copy to a collection with the same name as the class', () => result?.copies.mongoDB.collectionName.value.should.equal('collection-name'));
+    it('should not have any conversions', () => result?.copies.mongoDB.conversions.should.be.empty);
+});

--- a/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/without_copy_to_mongodb.ts
+++ b/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/without_copy_to_mongodb.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describeThis } from '@dolittle/typescript.testing';
+import { stubInterface } from 'ts-sinon';
+
+import { IEventTypes, ScopeId } from '@dolittle/sdk.events';
+import { IClientBuildResults } from '@dolittle/sdk.common';
+
+import { ProjectionId } from '../../../../ProjectionId';
+import { on } from '../../../onDecorator';
+import { ProjectionDecoratedType } from '../../../ProjectionDecoratedType';
+import { ProjectionClassBuilder } from '../../../ProjectionClassBuilder';
+
+class Projection {
+    @on('32e2aaca-2374-42f0-bcb5-7fb19501e3da', _ => _.keyFromEventSource())
+    on() {}
+}
+
+describeThis(__filename, () => {
+    const decoratedType = new ProjectionDecoratedType(
+        ProjectionId.from('53cad890-5b8a-4146-acce-29dc2dc8c43e'),
+        ScopeId.from('28f6c232-cc11-493b-b032-398a5e651617'),
+        Projection);
+
+    const builder = new ProjectionClassBuilder(decoratedType);
+
+    const event_types = stubInterface<IEventTypes>();
+    const build_results = stubInterface<IClientBuildResults>();
+
+    const result = builder.build(event_types, build_results);
+
+    it('should return a projection', () => result!.should.not.be.undefined);
+    it('should set copy to MongoDB', () => result?.copies.mongoDB.shouldCopyToMongoDB.should.be.false);
+});

--- a/Source/projections/Copies/MongoDB/CollectionName.ts
+++ b/Source/projections/Copies/MongoDB/CollectionName.ts
@@ -3,6 +3,8 @@
 
 import { ConceptAs, createIsConceptAsString } from '@dolittle/concepts';
 
+import { InvalidCollectionName } from './InvalidCollectionName';
+
 /**
  * Defines the types that can be converted into a {@link CollectionName}.
  */
@@ -18,6 +20,34 @@ export class CollectionName extends ConceptAs<string, '@dolittle/sdk.projections
      */
     constructor(name: string) {
         super(name, '@dolittle/sdk.projections.Copies.MongoDB.CollectionName');
+    }
+
+    /**
+     * Checks if the collection name is considered a valid MongoDB collection name.
+     * @returns {[true] | [false, Error]} A value indicating whether or not the collection name is valid, and potentially an error describing why not.
+     */
+    isValid(): [true] | [false, Error] {
+        if (this.value === undefined || this.value === null || this.value.trim().length < 1) {
+            return [false, new InvalidCollectionName(this, 'must not be null or empty')];
+        }
+
+        if (new TextEncoder().encode(this.value).length >= 120) {
+            return [false, new InvalidCollectionName(this, 'must be at most 120 bytes long')];
+        }
+
+        if (this.value.includes('$')) {
+            return [false, new InvalidCollectionName(this, 'cannot contain the character "$"')];
+        }
+
+        if (this.value.includes('\0')) {
+            return [false, new InvalidCollectionName(this, 'cannot contain the null character')];
+        }
+
+        if (this.value.startsWith('system.')) {
+            return [false, new InvalidCollectionName(this, 'cannot start with "system."')];
+        }
+
+        return [true];
     }
 
     /**

--- a/Source/projections/Copies/MongoDB/Conversion.ts
+++ b/Source/projections/Copies/MongoDB/Conversion.ts
@@ -16,7 +16,37 @@ export enum Conversion {
     Date = 1,
 
     /**
-     * Converts the field into a BSON Binary Guid.
+     * Converts the field into a BSON Array with .NET ticks and offset in minutes as elements.
      */
-    Guid = 2,
+    DateAsArray = 2,
+
+    /**
+     * Converts the field into a BSON Document with Date, .NET ticks and offset in minutes as properties.
+     */
+    DateAsDocument = 3,
+
+    /**
+     * Converts the field into a BSON String formatted like JavaScript Date.toString().
+     */
+    DateAsString = 4,
+
+    /**
+     * Converts the field into a BSON Int64 with .NET ticks as value.
+     */
+    DateAsInt64 = 5,
+
+    /**
+     * Converts the field into a BSON Binary with standard Guid representation.
+     */
+    Guid = 6,
+
+    /**
+     * Converts the field into a BSON Binary with C# legacy Guid representation.
+     */
+    GuidAsCSharpLegacy = 7,
+
+    /**
+     * Converts the field into a BSON String from a parsed Guid.
+     */
+    GuidAsString = 8,
 }

--- a/Source/projections/Copies/MongoDB/InvalidCollectionName.ts
+++ b/Source/projections/Copies/MongoDB/InvalidCollectionName.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Exception } from '@dolittle/rudiments';
+
+import { CollectionName } from './CollectionName';
+
+/**
+ * The exception that gets thrown when trying to copy projection read models to an invalid MongoDB collection name.
+ */
+export class InvalidCollectionName extends Exception {
+    /**
+     * Initialises a new instance of the {@link InvalidCollectionName} class.
+     * @param {CollectionName} name - The collection name that is invalid.
+     * @param {string} reason - The reason why the collection name is invalid.
+     */
+    constructor(name: CollectionName, reason: string) {
+        super(`The collection name '${name}', is invalid. Collection names ${reason}`);
+    }
+}

--- a/Source/projections/Copies/MongoDB/_exports.ts
+++ b/Source/projections/Copies/MongoDB/_exports.ts
@@ -3,6 +3,7 @@
 
 export { CollectionName, CollectionNameLike, isCollectionName } from './CollectionName';
 export { Conversion } from './Conversion';
+export { InvalidCollectionName } from './InvalidCollectionName';
 export { MongoDBCopies } from './MongoDBCopies';
 export { PropertyConversion } from './PropertyConversion';
 export { UnknownMongoDBConversion } from './UnknownMongoDBConversion';

--- a/Source/projections/Internal/ProjectionProcessor.ts
+++ b/Source/projections/Internal/ProjectionProcessor.ts
@@ -108,8 +108,14 @@ export class ProjectionProcessor<T> extends Internal.EventProcessor<ProjectionId
 
             const pbConversionType =
                 conversion.convertTo === Conversion.None ? ProjectionCopyToMongoDB.BSONType.NONE :
-                conversion.convertTo === Conversion.Date ? ProjectionCopyToMongoDB.BSONType.DATE :
-                conversion.convertTo === Conversion.Guid ? ProjectionCopyToMongoDB.BSONType.GUID :
+                conversion.convertTo === Conversion.Date ? ProjectionCopyToMongoDB.BSONType.DATEASDATE :
+                conversion.convertTo === Conversion.DateAsArray ? ProjectionCopyToMongoDB.BSONType.DATEASARRAY :
+                conversion.convertTo === Conversion.DateAsDocument ? ProjectionCopyToMongoDB.BSONType.DATEASDOCUMENT :
+                conversion.convertTo === Conversion.DateAsString ? ProjectionCopyToMongoDB.BSONType.DATEASSTRING :
+                conversion.convertTo === Conversion.DateAsInt64 ? ProjectionCopyToMongoDB.BSONType.DATEASINT64 :
+                conversion.convertTo === Conversion.Guid ? ProjectionCopyToMongoDB.BSONType.GUIDASSTANDARDBINARY :
+                conversion.convertTo === Conversion.GuidAsCSharpLegacy ? ProjectionCopyToMongoDB.BSONType.GUIDASCSHARPLEGACYBINARY :
+                conversion.convertTo === Conversion.GuidAsString ? ProjectionCopyToMongoDB.BSONType.GUIDASSTRING :
                 undefined;
             if (pbConversionType === undefined) {
                 throw new UnknownMongoDBConversion(conversion.convertTo);

--- a/Source/projections/index.ts
+++ b/Source/projections/index.ts
@@ -56,6 +56,7 @@ export {
     CollectionNameLike as MongoDBCollectionNameLike,
     isCollectionName as isMongoDBCollectionName,
     Conversion as MongoDBConversion,
+    InvalidCollectionName,
     MongoDBCopies,
     PropertyConversion,
     UnknownMongoDBConversion,

--- a/Source/projections/package.json
+++ b/Source/projections/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.2",
+        "@dolittle/contracts": "6.6.0-sam.3",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.2",
+        "@dolittle/runtime.contracts": "6.6.0-sam.3",
         "@dolittle/sdk.artifacts": "22.2.0-sam.3",
         "@dolittle/sdk.common": "22.2.0-sam.3",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.3",

--- a/Source/protobuf/package.json
+++ b/Source/protobuf/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.2",
+        "@dolittle/contracts": "6.6.0-sam.3",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.artifacts": "22.2.0-sam.3",
         "@dolittle/sdk.execution": "22.2.0-sam.3"

--- a/Source/resources/package.json
+++ b/Source/resources/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.2",
+        "@dolittle/contracts": "6.6.0-sam.3",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.2",
+        "@dolittle/runtime.contracts": "6.6.0-sam.3",
         "@dolittle/sdk.execution": "22.2.0-sam.3",
         "@dolittle/sdk.projections": "22.2.0-sam.3",
         "@dolittle/sdk.protobuf": "22.2.0-sam.3",

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -45,7 +45,7 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/runtime.contracts": "6.6.0-sam.2",
+        "@dolittle/runtime.contracts": "6.6.0-sam.3",
         "@dolittle/sdk.aggregates": "22.2.0-sam.3",
         "@dolittle/sdk.artifacts": "22.2.0-sam.3",
         "@dolittle/sdk.common": "22.2.0-sam.3",

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.2",
+        "@dolittle/contracts": "6.6.0-sam.3",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.common": "22.2.0-sam.3",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.3",

--- a/Source/tenancy/package.json
+++ b/Source/tenancy/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.2",
+        "@dolittle/runtime.contracts": "6.6.0-sam.3",
         "@dolittle/sdk.execution": "22.2.0-sam.3",
         "@dolittle/sdk.protobuf": "22.2.0-sam.3",
         "@dolittle/sdk.resilience": "22.2.0-sam.3",


### PR DESCRIPTION
## Summary

Adds validation that fails during build of Projections if copy to MongoDB collection name is not valid. Also upgrades contracts, and upgrades to the new contracts and adds enums for new conversion types.

Also added some specs for verifying that the copy to MongoDB specifications are correct when using decorators on classes and when using the explicit builder.