### PR TITLE
Fix samples and upgrade to released contracts

### DIFF
--- a/Samples/MongoDBProjections/.eslintrc.js
+++ b/Samples/MongoDBProjections/.eslintrc.js
@@ -4,7 +4,8 @@
 module.exports = {
     extends: '../../.eslintrc.js',
     rules: {
-        "no-restricted-globals": 'off',
+        'no-restricted-globals': 'off',
+        '@typescript-eslint/naming-convention' : 'off',
         'jsdoc/require-jsdoc': 'off',
     }
 };

--- a/Samples/MongoDBProjections/.eslintrc.js
+++ b/Samples/MongoDBProjections/.eslintrc.js
@@ -1,0 +1,10 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+module.exports = {
+    extends: '../../.eslintrc.js',
+    rules: {
+        "no-restricted-globals": 'off',
+        'jsdoc/require-jsdoc': 'off',
+    }
+};

--- a/Samples/MongoDBProjections/DishCounter.ts
+++ b/Samples/MongoDBProjections/DishCounter.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { convertToMongoDB, copyProjectionToMongoDB, on, projection, MongoDBConversion, ProjectionContext } from '@dolittle/sdk.projections';
+
+import { DishPrepared } from './DishPrepared';
+
+@projection('98f9db66-b6ca-4e5f-9fc3-638626c9ecfa')
+@copyProjectionToMongoDB()
+export class DishCounter {
+
+    name: string = 'Unknown';
+
+    numberOfTimesPrepared: number = 0;
+
+    @convertToMongoDB(MongoDBConversion.Date)
+    lastPrepared: Date = new Date(0);
+
+    @on(DishPrepared, _ => _.keyFromProperty('Dish'))
+    on(event: DishPrepared, projectionContext: ProjectionContext) {
+        this.name = event.Dish;
+        this.numberOfTimesPrepared ++;
+        this.lastPrepared = projectionContext.eventContext.occurred.toJSDate();
+    }
+}

--- a/Samples/MongoDBProjections/DishPrepared.ts
+++ b/Samples/MongoDBProjections/DishPrepared.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { eventType } from '@dolittle/sdk.events';
+
+@eventType('1844473f-d714-4327-8b7f-5b3c2bdfc26a')
+export class DishPrepared {
+    constructor(readonly Dish: string, readonly Chef: string) {}
+}

--- a/Samples/MongoDBProjections/index.ts
+++ b/Samples/MongoDBProjections/index.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Sample code for the tutorial at https://dolittle.io/docs/tutorials/projections/
+
+import { DolittleClient } from '@dolittle/sdk';
+import { TenantId } from '@dolittle/sdk.execution';
+import { setTimeout } from 'timers/promises';
+import { DateTime } from 'luxon';
+
+import { DishCounter } from './DishCounter';
+import { DishPrepared } from './DishPrepared';
+
+(async () => {
+    const client = await DolittleClient
+        .setup()
+        .connect();
+
+    const eventStore = client.eventStore.forTenant(TenantId.development);
+
+    await eventStore.commit(new DishPrepared('Bean Blaster Taco', 'Mr. Taco'), 'Dolittle Tacos');
+    await eventStore.commit(new DishPrepared('Bean Blaster Taco', 'Mrs. Tex Mex'), 'Dolittle Tacos');
+    await eventStore.commit(new DishPrepared('Avocado Artillery Tortilla', 'Mr. Taco'), 'Dolittle Tacos');
+    await eventStore.commit(new DishPrepared('Chili Canon Wrap', 'Mrs. Tex Mex'), 'Dolittle Tacos');
+
+    await setTimeout(1000);
+
+    const db = await client.resources.forTenant(TenantId.development).mongoDB.getDatabase();
+    const dishCounterCollection = db.collection(DishCounter);
+
+    for (const { name, numberOfTimesPrepared, lastPrepared } of await dishCounterCollection.find().toArray()) {
+        client.logger.info(`The kitchen has prepared ${name} ${numberOfTimesPrepared} times. The last time was ${lastPrepared}`);
+    }
+
+    const dishesPreparedToday = await dishCounterCollection.find({ lastPrepared: { $gte: DateTime.utc().startOf('day').toJSDate(), $lte: DateTime.utc().endOf('day').toJSDate() }}).toArray();
+    for (const { name } of await dishCounterCollection.find().toArray()) {
+        client.logger.info(`The kitchen has prepared ${name} today`);
+    }
+})();

--- a/Samples/MongoDBProjections/package.json
+++ b/Samples/MongoDBProjections/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "mongodb-projections",
+    "private": true,
+    "version": "22.2.0-sam.4",
+    "main": "index.js",
+    "author": "Dolittle",
+    "license": "MIT",
+    "scripts": {
+        "watch": "nodemon --watch **/*.ts --exec 'ts-node' index.ts",
+        "start": "ts-node index.ts",
+        "test": "mocha",
+        "build": "tsc -p ./tsconfig.json"
+    },
+    "dependencies": {
+        "@dolittle/sdk": "22.2.0-sam.4",
+        "@dolittle/sdk.artifacts": "22.2.0-sam.4",
+        "@dolittle/sdk.events": "22.2.0-sam.4",
+        "@dolittle/sdk.events.handling": "22.2.0-sam.4",
+        "inversify": "^6.0.1",
+        "reflect-metadata": "^0.1.13",
+        "winston": "^3.3.4"
+    },
+    "devDependencies": {
+        "nodemon": "^2.0.4",
+        "ts-node": "^8.10.1"
+    }
+}

--- a/Samples/MongoDBProjections/tsconfig.json
+++ b/Samples/MongoDBProjections/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "extends": "../../tsconfig.settings.json",
+    "compilerOptions": {
+        "sourceRoot": "../",
+        "inlineSourceMap": true,
+        "sourceMap": false,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "outDir": "Distribution"
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["node_modules", "Distribution"],
+    "references": [
+        { "path": "../../Source/sdk" }
+    ]
+}

--- a/Samples/Tutorials/Projections/Chef.ts
+++ b/Samples/Tutorials/Projections/Chef.ts
@@ -6,7 +6,6 @@
 export class Chef {
     constructor(
         public name: string = '',
-        public dishes: string[] = [],
-        public lastPreparedDish: Date = new Date(0),
+        public dishes: string[] = []
     ) { }
 }

--- a/Samples/Tutorials/Projections/DishCounter.ts
+++ b/Samples/Tutorials/Projections/DishCounter.ts
@@ -3,14 +3,12 @@
 
 // Sample code for the tutorial at https://dolittle.io/tutorials/projections/typescript/
 
-import { ProjectionContext, projection, on, copyProjectionToMongoDB } from '@dolittle/sdk.projections';
+import { ProjectionContext, projection, on } from '@dolittle/sdk.projections';
 
 import { DishPrepared } from './DishPrepared';
 
 @projection('98f9db66-b6ca-4e5f-9fc3-638626c9ecfa')
-@copyProjectionToMongoDB()
 export class DishCounter {
-
     name: string = 'Unknown';
     numberOfTimesPrepared: number = 0;
 

--- a/Samples/Tutorials/Projections/index.ts
+++ b/Samples/Tutorials/Projections/index.ts
@@ -5,7 +5,6 @@
 
 import { DolittleClient } from '@dolittle/sdk';
 import { TenantId } from '@dolittle/sdk.execution';
-import { MongoDBConversion } from '@dolittle/sdk.projections';
 import { setTimeout } from 'timers/promises';
 
 import { Chef } from './Chef';
@@ -18,12 +17,8 @@ import { DishPrepared } from './DishPrepared';
             .withProjections(_ => _
                 .create('0767bc04-bc03-40b8-a0be-5f6c6130f68b')
                     .forReadModel(Chef)
-                    .copyToMongoDB(_ => _
-                        .withConversion('lastPreparedDish', MongoDBConversion.Date)
-                    )
                     .on(DishPrepared, _ => _.keyFromProperty('Chef'), (chef, event, projectionContext) => {
                         chef.name = event.Chef;
-                        chef.lastPreparedDish = new Date();
                         if (!chef.dishes.includes(event.Dish)) chef.dishes.push(event.Dish);
                         return chef;
                     })

--- a/Source/artifacts/package.json
+++ b/Source/artifacts/package.json
@@ -47,7 +47,7 @@
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/types": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.3"
+        "@dolittle/runtime.contracts": "6.6.0"
     },
     "devDependencies": {
         "@types/is-natural-number": "^4.0.0"

--- a/Source/embeddings/package.json
+++ b/Source/embeddings/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.3",
+        "@dolittle/contracts": "6.6.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.3",
+        "@dolittle/runtime.contracts": "6.6.0",
         "@dolittle/sdk.artifacts": "22.2.0-sam.4",
         "@dolittle/sdk.common": "22.2.0-sam.4",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.4",

--- a/Source/eventHorizon/package.json
+++ b/Source/eventHorizon/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.3",
+        "@dolittle/runtime.contracts": "6.6.0",
         "@dolittle/sdk.events": "22.2.0-sam.4",
         "@dolittle/sdk.execution": "22.2.0-sam.4",
         "@dolittle/sdk.protobuf": "22.2.0-sam.4",

--- a/Source/events.filtering/package.json
+++ b/Source/events.filtering/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.3",
+        "@dolittle/contracts": "6.6.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.3",
+        "@dolittle/runtime.contracts": "6.6.0",
         "@dolittle/sdk.common": "22.2.0-sam.4",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.4",
         "@dolittle/sdk.events": "22.2.0-sam.4",

--- a/Source/events.handling/package.json
+++ b/Source/events.handling/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.3",
+        "@dolittle/contracts": "6.6.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.3",
+        "@dolittle/runtime.contracts": "6.6.0",
         "@dolittle/sdk.artifacts": "22.2.0-sam.4",
         "@dolittle/sdk.common": "22.2.0-sam.4",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.4",

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.3",
+        "@dolittle/contracts": "6.6.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.3",
+        "@dolittle/runtime.contracts": "6.6.0",
         "@dolittle/sdk.common": "22.2.0-sam.4",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.4",
         "@dolittle/sdk.execution": "22.2.0-sam.4",

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.3",
+        "@dolittle/contracts": "6.6.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.3",
+        "@dolittle/runtime.contracts": "6.6.0",
         "@dolittle/sdk.artifacts": "22.2.0-sam.4",
         "@dolittle/sdk.execution": "22.2.0-sam.4",
         "@dolittle/sdk.protobuf": "22.2.0-sam.4",

--- a/Source/projections/package.json
+++ b/Source/projections/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.3",
+        "@dolittle/contracts": "6.6.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.3",
+        "@dolittle/runtime.contracts": "6.6.0",
         "@dolittle/sdk.artifacts": "22.2.0-sam.4",
         "@dolittle/sdk.common": "22.2.0-sam.4",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.4",

--- a/Source/protobuf/package.json
+++ b/Source/protobuf/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.3",
+        "@dolittle/contracts": "6.6.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.artifacts": "22.2.0-sam.4",
         "@dolittle/sdk.execution": "22.2.0-sam.4"

--- a/Source/resources/package.json
+++ b/Source/resources/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.3",
+        "@dolittle/contracts": "6.6.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.3",
+        "@dolittle/runtime.contracts": "6.6.0",
         "@dolittle/sdk.execution": "22.2.0-sam.4",
         "@dolittle/sdk.projections": "22.2.0-sam.4",
         "@dolittle/sdk.protobuf": "22.2.0-sam.4",

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -45,7 +45,7 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/runtime.contracts": "6.6.0-sam.3",
+        "@dolittle/runtime.contracts": "6.6.0",
         "@dolittle/sdk.aggregates": "22.2.0-sam.4",
         "@dolittle/sdk.artifacts": "22.2.0-sam.4",
         "@dolittle/sdk.common": "22.2.0-sam.4",

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0-sam.3",
+        "@dolittle/contracts": "6.6.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.common": "22.2.0-sam.4",
         "@dolittle/sdk.dependencyinversion": "22.2.0-sam.4",

--- a/Source/tenancy/package.json
+++ b/Source/tenancy/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0-sam.3",
+        "@dolittle/runtime.contracts": "6.6.0",
         "@dolittle/sdk.execution": "22.2.0-sam.4",
         "@dolittle/sdk.protobuf": "22.2.0-sam.4",
         "@dolittle/sdk.resilience": "22.2.0-sam.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "Samples/Tutorials/EventHorizon/Consumer",
     "Samples/Tutorials/EventHorizon/Producer",
     "Samples/Container",
-    "Samples/ExpressJS"
+    "Samples/ExpressJS",
+    "Samples/MongoDBProjections"
   ],
   "scripts": {
     "prebuild": "yarn clean && yarn copy-readme",


### PR DESCRIPTION
## Summary

Revert Tutorials/Projections, and add new MongoDBProjections sample. Upgrade to released contracts, and checked that it works with the released Runtime.