### PR TITLE
Implement key selectors

### DIFF
--- a/Source/artifacts/package.json
+++ b/Source/artifacts/package.json
@@ -47,7 +47,7 @@
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/types": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0"
+        "@dolittle/runtime.contracts": "6.7.0"
     },
     "devDependencies": {
         "@types/is-natural-number": "^4.0.0"

--- a/Source/embeddings/package.json
+++ b/Source/embeddings/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0",
+        "@dolittle/contracts": "6.7.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0",
+        "@dolittle/runtime.contracts": "6.7.0",
         "@dolittle/sdk.artifacts": "23.0.0",
         "@dolittle/sdk.common": "23.0.0",
         "@dolittle/sdk.dependencyinversion": "23.0.0",

--- a/Source/eventHorizon/package.json
+++ b/Source/eventHorizon/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0",
+        "@dolittle/runtime.contracts": "6.7.0",
         "@dolittle/sdk.events": "23.0.0",
         "@dolittle/sdk.execution": "23.0.0",
         "@dolittle/sdk.protobuf": "23.0.0",

--- a/Source/events.filtering/package.json
+++ b/Source/events.filtering/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0",
+        "@dolittle/contracts": "6.7.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0",
+        "@dolittle/runtime.contracts": "6.7.0",
         "@dolittle/sdk.common": "23.0.0",
         "@dolittle/sdk.dependencyinversion": "23.0.0",
         "@dolittle/sdk.events": "23.0.0",

--- a/Source/events.handling/package.json
+++ b/Source/events.handling/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0",
+        "@dolittle/contracts": "6.7.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0",
+        "@dolittle/runtime.contracts": "6.7.0",
         "@dolittle/sdk.artifacts": "23.0.0",
         "@dolittle/sdk.common": "23.0.0",
         "@dolittle/sdk.dependencyinversion": "23.0.0",

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0",
+        "@dolittle/contracts": "6.7.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0",
+        "@dolittle/runtime.contracts": "6.7.0",
         "@dolittle/sdk.common": "23.0.0",
         "@dolittle/sdk.dependencyinversion": "23.0.0",
         "@dolittle/sdk.execution": "23.0.0",

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0",
+        "@dolittle/contracts": "6.7.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0",
+        "@dolittle/runtime.contracts": "6.7.0",
         "@dolittle/sdk.artifacts": "23.0.0",
         "@dolittle/sdk.execution": "23.0.0",
         "@dolittle/sdk.protobuf": "23.0.0",

--- a/Source/projections/Builders/KeySelectorBuilder.ts
+++ b/Source/projections/Builders/KeySelectorBuilder.ts
@@ -1,9 +1,13 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { EventOccurredKeySelector } from '../EventOccurredKeySelector';
 import { EventPropertyKeySelector } from '../EventPropertyKeySelector';
 import { EventSourceIdKeySelector } from '../EventSourceIdKeySelector';
+import { Key } from '../Key';
+import { OccurredFormat } from '../OccurredFormat';
 import { PartitionIdKeySelector } from '../PartitionIdKeySelector';
+import { StaticKeySelector } from '../StaticKeySelector';
 
 /**
  * Represents a builder for building {@link KeySelector}.
@@ -34,4 +38,23 @@ export class KeySelectorBuilder<T = any> {
     keyFromProperty(property: keyof T): EventPropertyKeySelector {
         return new EventPropertyKeySelector(property as string);
     }
+
+    /**
+     * Sets a static key as projection key.
+     * @param {string | Key} key - The property to use as key.
+     * @returns {StaticKeySelector} A key selector.
+     */
+    staticKey(key: string | Key): StaticKeySelector {
+        return new StaticKeySelector(key);
+    }
+
+    /**
+     * Select projection key from the given format of when an event occurred.
+     * @param {string | OccurredFormat} occurredFormat - The occurred format.
+     * @returns {StaticKeySelector} A key selector.
+     */
+    keyFromEventOccurred(occurredFormat: string | OccurredFormat): EventOccurredKeySelector {
+        return new EventOccurredKeySelector(occurredFormat);
+    }
+
 }

--- a/Source/projections/EventOccurredKeySelector.ts
+++ b/Source/projections/EventOccurredKeySelector.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { OccurredFormat } from './OccurredFormat';
+
+/**
+ * Represents an event occurred key selector.
+ */
+export class EventOccurredKeySelector {
+    readonly occurredFormat: OccurredFormat;
+
+    /**
+     * Initializes a new instance of {@link OccurredFormat}.
+     * @param {OccurredFormat | string} occurredFormat - The occurred format to use as format for getting key from event occurred metadata.
+     */
+    constructor(occurredFormat: OccurredFormat | string) {
+        this.occurredFormat = OccurredFormat.from(occurredFormat);
+    }
+}

--- a/Source/projections/EventOccurredKeySelector.ts
+++ b/Source/projections/EventOccurredKeySelector.ts
@@ -10,7 +10,7 @@ export class EventOccurredKeySelector {
     readonly occurredFormat: OccurredFormat;
 
     /**
-     * Initializes a new instance of {@link OccurredFormat}.
+     * Initializes a new instance of the {@link EventOccurredKeySelector} class.
      * @param {OccurredFormat | string} occurredFormat - The occurred format to use as format for getting key from event occurred metadata.
      */
     constructor(occurredFormat: OccurredFormat | string) {

--- a/Source/projections/Internal/ProjectionProcessor.ts
+++ b/Source/projections/Internal/ProjectionProcessor.ts
@@ -18,6 +18,7 @@ import { ProcessorFailure, RetryProcessingState } from '@dolittle/runtime.contra
 import { ProjectionsClient } from '@dolittle/runtime.contracts/Events.Processing/Projections_grpc_pb';
 import {
     EventPropertyKeySelector as ProtobufEventPropertyKeySelector, EventSourceIdKeySelector as ProtobufEventSourceIdKeySelector, PartitionIdKeySelector as ProtobufPartitionIdKeySelector, ProjectionClientToRuntimeMessage, ProjectionCopies, ProjectionCopyToMongoDB, ProjectionDeleteResponse, ProjectionEventSelector, ProjectionRegistrationRequest,
+    StaticKeySelector as ProtobufStaticKeySelector, EventOccurredKeySelector as ProtobufEventOccurredKeySelector,
     ProjectionRegistrationResponse, ProjectionReplaceResponse, ProjectionRequest,
     ProjectionResponse, ProjectionRuntimeToClientMessage
 } from '@dolittle/runtime.contracts/Events.Processing/Projections_pb';
@@ -36,6 +37,8 @@ import { UnknownKeySelectorType } from '../UnknownKeySelectorType';
 import { Conversion } from '../Copies/MongoDB/Conversion';
 import { UnknownMongoDBConversion } from '../Copies/MongoDB/UnknownMongoDBConversion';
 import { PropertyConversion } from '../Copies/MongoDB/PropertyConversion';
+import { StaticKeySelector } from '../StaticKeySelector';
+import { EventOccurredKeySelector } from '../EventOccurredKeySelector';
 
 /**
  * Represents an implementation of {@link Internal.EventProcessor} for {@link Projection}.
@@ -82,6 +85,14 @@ export class ProjectionProcessor<T> extends Internal.EventProcessor<ProjectionId
             protobufSelector.setEventsourcekeyselector(new ProtobufEventSourceIdKeySelector());
         } else if (selector instanceof PartitionIdKeySelector) {
             protobufSelector.setPartitionkeyselector(new ProtobufPartitionIdKeySelector());
+        } else if (selector instanceof StaticKeySelector) {
+            const staticKeySelector = new ProtobufStaticKeySelector();
+            staticKeySelector.setStatickey(selector.staticKey.value);
+            protobufSelector.setStatickeyselector(staticKeySelector);
+        } else if (selector instanceof EventOccurredKeySelector) {
+            const eventOccurredKeySelector = new ProtobufEventOccurredKeySelector();
+            eventOccurredKeySelector.setFormat(selector.occurredFormat.value);
+            protobufSelector.setEventoccurredkeyselector(eventOccurredKeySelector);
         } else {
             throw new UnknownKeySelectorType(selector);
         }

--- a/Source/projections/KeySelector.ts
+++ b/Source/projections/KeySelector.ts
@@ -1,11 +1,13 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { EventOccurredKeySelector } from './EventOccurredKeySelector';
 import { EventPropertyKeySelector } from './EventPropertyKeySelector';
 import { EventSourceIdKeySelector } from './EventSourceIdKeySelector';
 import { PartitionIdKeySelector } from './PartitionIdKeySelector';
+import { StaticKeySelector } from './StaticKeySelector';
 
 /**
  * Represents a key selector.
  */
- export type KeySelector = EventPropertyKeySelector | EventSourceIdKeySelector | PartitionIdKeySelector;
+ export type KeySelector = EventPropertyKeySelector | EventSourceIdKeySelector | PartitionIdKeySelector | StaticKeySelector | EventOccurredKeySelector;

--- a/Source/projections/OccurredFormat.ts
+++ b/Source/projections/OccurredFormat.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ConceptAs } from '@dolittle/concepts';
+
+/**
+ * Represents the format used to represent the date time mapping of when events occurred to projections.
+ */
+export class OccurredFormat extends ConceptAs<string, '@dolittle/sdk.projections.OccurredFormat'> {
+    /**
+     * Initializes a new instance of {@link PropertyNameKeySelector}.
+     * @param {string} format - The event occurred format.
+     */
+    constructor(format: string) {
+        super(format, '@dolittle/sdk.projections.OccurredFormat');
+    }
+
+    /**
+     * Creates a {@link OccurredFormat} from a string.
+     * @param {string | OccurredFormat} format - The format to convert.
+     * @returns {OccurredFormat} The converted key selector.
+     */
+    static from(format: string | OccurredFormat): OccurredFormat {
+        if (format instanceof OccurredFormat) { return format; }
+        return new OccurredFormat(format);
+    }
+}

--- a/Source/projections/StaticKeySelector.ts
+++ b/Source/projections/StaticKeySelector.ts
@@ -10,7 +10,7 @@ export class StaticKeySelector {
     readonly staticKey: Key;
 
     /**
-     * Initializes a new instance of {@link Key}.
+     * Initializes a new instance of the {@link StaticKeySelector} class.
      * @param {Key | string} key - The static key to use as projection key.
      */
     constructor(key: Key | string) {

--- a/Source/projections/StaticKeySelector.ts
+++ b/Source/projections/StaticKeySelector.ts
@@ -4,7 +4,7 @@
 import { Key } from './Key';
 
 /**
- * Represents an event occurred key selector.
+ * Represents a static key selector.
  */
 export class StaticKeySelector {
     readonly staticKey: Key;

--- a/Source/projections/StaticKeySelector.ts
+++ b/Source/projections/StaticKeySelector.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Key } from './Key';
+
+/**
+ * Represents an event occurred key selector.
+ */
+export class StaticKeySelector {
+    readonly staticKey: Key;
+
+    /**
+     * Initializes a new instance of {@link Key}.
+     * @param {Key | string} key - The static key to use as projection key.
+     */
+    constructor(key: Key | string) {
+        this.staticKey = Key.from(key);
+    }
+}

--- a/Source/projections/_exports.ts
+++ b/Source/projections/_exports.ts
@@ -7,6 +7,8 @@ export * as Store from './Store/_exports';
 
 export { DeleteReadModelInstance } from './DeleteReadModelInstance';
 export { EventPropertyKeySelector } from './EventPropertyKeySelector';
+export { EventOccurredKeySelector } from './EventOccurredKeySelector';
+export { StaticKeySelector } from './StaticKeySelector';
 export { EventSelector } from './EventSelector';
 export { EventSourceIdKeySelector } from './EventSourceIdKeySelector';
 export { IProjection } from './IProjection';
@@ -23,4 +25,5 @@ export { ProjectionModelId, isProjectionModelId } from './ProjectionModelId';
 export { ProjectionResult } from './ProjectionResult';
 export { Projections } from './Projections';
 export { PropertyNameKeySelector } from './PropertyNameKeySelector';
+export { OccurredFormat } from './OccurredFormat';
 export { UnknownKeySelectorType } from './UnknownKeySelectorType';

--- a/Source/projections/package.json
+++ b/Source/projections/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0",
+        "@dolittle/contracts": "6.7.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0",
+        "@dolittle/runtime.contracts": "6.7.0",
         "@dolittle/sdk.artifacts": "23.0.0",
         "@dolittle/sdk.common": "23.0.0",
         "@dolittle/sdk.dependencyinversion": "23.0.0",

--- a/Source/protobuf/package.json
+++ b/Source/protobuf/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0",
+        "@dolittle/contracts": "6.7.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.artifacts": "23.0.0",
         "@dolittle/sdk.execution": "23.0.0"

--- a/Source/resources/package.json
+++ b/Source/resources/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0",
+        "@dolittle/contracts": "6.7.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0",
+        "@dolittle/runtime.contracts": "6.7.0",
         "@dolittle/sdk.execution": "23.0.0",
         "@dolittle/sdk.projections": "23.0.0",
         "@dolittle/sdk.protobuf": "23.0.0",

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -45,7 +45,7 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/runtime.contracts": "6.6.0",
+        "@dolittle/runtime.contracts": "6.7.0",
         "@dolittle/sdk.aggregates": "23.0.0",
         "@dolittle/sdk.artifacts": "23.0.0",
         "@dolittle/sdk.common": "23.0.0",

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.6.0",
+        "@dolittle/contracts": "6.7.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.common": "23.0.0",
         "@dolittle/sdk.dependencyinversion": "23.0.0",

--- a/Source/tenancy/package.json
+++ b/Source/tenancy/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.6.0",
+        "@dolittle/runtime.contracts": "6.7.0",
         "@dolittle/sdk.execution": "23.0.0",
         "@dolittle/sdk.protobuf": "23.0.0",
         "@dolittle/sdk.resilience": "23.0.0",


### PR DESCRIPTION
## Summary

Adds two new event key selectors to projections, `StaticKey` and `KeyFromEventOccurred`

### Added

- `staticKey` event key selector attribute for projection On-methods that sets a constant, static, key as the key of the read model
- `keyFromEventOccurred` event key selector for projection On-methods that uses the event occurred metadata as the key for the projection read models formatted as the string given to the attribute. We currently support these formats:
    - yyyy-MM-dd
    - yyyy-MM
    - yyyy
    - HH:mm:ss
    - hh:mm:ss
    - HH:mm
    - hh:mm
    - HH
    - hh
    - yyyy-MM-dd HH:mm:ss
    - And the above in different orderings 
