### PR TITLE
Projection alias

### DIFF
--- a/Source/artifacts/package.json
+++ b/Source/artifacts/package.json
@@ -47,7 +47,7 @@
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/types": "6.0.0",
-        "@dolittle/runtime.contracts": "6.7.0"
+        "@dolittle/runtime.contracts": "6.8.0-merry.2"
     },
     "devDependencies": {
         "@types/is-natural-number": "^4.0.0"

--- a/Source/artifacts/package.json
+++ b/Source/artifacts/package.json
@@ -47,7 +47,7 @@
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/types": "6.0.0",
-        "@dolittle/runtime.contracts": "6.8.0-merry.2"
+        "@dolittle/runtime.contracts": "6.8.0"
     },
     "devDependencies": {
         "@types/is-natural-number": "^4.0.0"

--- a/Source/embeddings/package.json
+++ b/Source/embeddings/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.7.0",
+        "@dolittle/contracts": "6.8.0-merry.2",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.7.0",
+        "@dolittle/runtime.contracts": "6.8.0-merry.2",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",

--- a/Source/embeddings/package.json
+++ b/Source/embeddings/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.8.0-merry.2",
+        "@dolittle/contracts": "6.8.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.8.0-merry.2",
+        "@dolittle/runtime.contracts": "6.8.0",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",

--- a/Source/eventHorizon/package.json
+++ b/Source/eventHorizon/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.8.0-merry.2",
+        "@dolittle/runtime.contracts": "6.8.0",
         "@dolittle/sdk.events": "23.1.0",
         "@dolittle/sdk.execution": "23.1.0",
         "@dolittle/sdk.protobuf": "23.1.0",

--- a/Source/eventHorizon/package.json
+++ b/Source/eventHorizon/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.7.0",
+        "@dolittle/runtime.contracts": "6.8.0-merry.2",
         "@dolittle/sdk.events": "23.1.0",
         "@dolittle/sdk.execution": "23.1.0",
         "@dolittle/sdk.protobuf": "23.1.0",

--- a/Source/events.filtering/package.json
+++ b/Source/events.filtering/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.8.0-merry.2",
+        "@dolittle/contracts": "6.8.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.8.0-merry.2",
+        "@dolittle/runtime.contracts": "6.8.0",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",
         "@dolittle/sdk.events": "23.1.0",

--- a/Source/events.filtering/package.json
+++ b/Source/events.filtering/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.7.0",
+        "@dolittle/contracts": "6.8.0-merry.2",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.7.0",
+        "@dolittle/runtime.contracts": "6.8.0-merry.2",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",
         "@dolittle/sdk.events": "23.1.0",

--- a/Source/events.handling/Builders/EventHandlerOptions.ts
+++ b/Source/events.handling/Builders/EventHandlerOptions.ts
@@ -10,4 +10,8 @@ import { EventHandlerAliasLike } from '../EventHandlerAlias';
 /**
  * Defines the options that can be defined in a {@link eventHandler} decorator.
  */
-export type EventHandlerOptions = { inScope?: ScopeId | Guid | string, partitioned?: boolean, alias?: EventHandlerAliasLike };
+export type EventHandlerOptions = {
+    inScope?: ScopeId | Guid | string,
+    partitioned?: boolean,
+    alias?: EventHandlerAliasLike,
+};

--- a/Source/events.handling/Builders/IEventHandlerBuilder.ts
+++ b/Source/events.handling/Builders/IEventHandlerBuilder.ts
@@ -32,7 +32,7 @@ export abstract class IEventHandlerBuilder {
     abstract inScope(scopeId: ScopeId | Guid | string): IEventHandlerBuilder;
 
     /**
-     * Defines and alias for the event handler.
+     * Defines an alias for the event handler.
      * @param {EventHandlerAliasLike} alias - The event handler alias.
      * @returns {IEventHandlerBuilder} The builder for continuation.
      */

--- a/Source/events.handling/EventHandler.ts
+++ b/Source/events.handling/EventHandler.ts
@@ -16,6 +16,7 @@ import { MissingEventHandlerForType } from './MissingEventHandlerForType';
  * Represents an implementation of {@link IEventHandler}.
  */
 export class EventHandler extends IEventHandler {
+    /** @inheritdoc */
     readonly hasAlias: boolean;
 
     /**

--- a/Source/events.handling/package.json
+++ b/Source/events.handling/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.7.0",
+        "@dolittle/contracts": "6.8.0-merry.2",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.7.0",
+        "@dolittle/runtime.contracts": "6.8.0-merry.2",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",

--- a/Source/events.handling/package.json
+++ b/Source/events.handling/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.8.0-merry.2",
+        "@dolittle/contracts": "6.8.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.8.0-merry.2",
+        "@dolittle/runtime.contracts": "6.8.0",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.7.0",
+        "@dolittle/contracts": "6.8.0-merry.2",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.7.0",
+        "@dolittle/runtime.contracts": "6.8.0-merry.2",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",
         "@dolittle/sdk.execution": "23.1.0",

--- a/Source/events.processing/package.json
+++ b/Source/events.processing/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.8.0-merry.2",
+        "@dolittle/contracts": "6.8.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.8.0-merry.2",
+        "@dolittle/runtime.contracts": "6.8.0",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",
         "@dolittle/sdk.execution": "23.1.0",

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.8.0-merry.2",
+        "@dolittle/contracts": "6.8.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.8.0-merry.2",
+        "@dolittle/runtime.contracts": "6.8.0",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.execution": "23.1.0",
         "@dolittle/sdk.protobuf": "23.1.0",

--- a/Source/events/package.json
+++ b/Source/events/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.7.0",
+        "@dolittle/contracts": "6.8.0-merry.2",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.7.0",
+        "@dolittle/runtime.contracts": "6.8.0-merry.2",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.execution": "23.1.0",
         "@dolittle/sdk.protobuf": "23.1.0",

--- a/Source/projections/Builders/IProjectionBuilderForReadModel.ts
+++ b/Source/projections/Builders/IProjectionBuilderForReadModel.ts
@@ -10,6 +10,7 @@ import { EventType, EventTypeIdLike, ScopeId } from '@dolittle/sdk.events';
 import { ProjectionCallback } from '../ProjectionCallback';
 import { CopyToMongoDBCallback } from './Copies/CopyToMongoDBCallback';
 import { KeySelectorBuilderCallback } from './KeySelectorBuilderCallback';
+import { ProjectionAliasLike } from '../ProjectionAlias';
 
 /**
  * Defines a builder for building a projection for a read model from method callbacks.
@@ -33,7 +34,7 @@ export abstract class IProjectionBuilderForReadModel<T> {
      * @param {ProjectionCallback<T>} callback - Callback to call for each event.
      * @returns {IProjectionBuilderForReadModel<T>} The builder for continuation.
      */
-     abstract on(eventType: EventType, keySelectorCallback: KeySelectorBuilderCallback, callback: ProjectionCallback<T>): IProjectionBuilderForReadModel<T>;
+    abstract on(eventType: EventType, keySelectorCallback: KeySelectorBuilderCallback, callback: ProjectionCallback<T>): IProjectionBuilderForReadModel<T>;
 
     /**
      * Add an on method for handling the event.
@@ -42,7 +43,7 @@ export abstract class IProjectionBuilderForReadModel<T> {
      * @param {ProjectionCallback<T>} callback - Callback to call for each event.
      * @returns {IProjectionBuilderForReadModel<T>} The builder for continuation.
      */
-     abstract on(eventTypeId: EventTypeIdLike, keySelectorCallback: KeySelectorBuilderCallback, callback: ProjectionCallback<T>): IProjectionBuilderForReadModel<T>;
+    abstract on(eventTypeId: EventTypeIdLike, keySelectorCallback: KeySelectorBuilderCallback, callback: ProjectionCallback<T>): IProjectionBuilderForReadModel<T>;
 
     /**
      * Add an on method for handling the event.
@@ -52,7 +53,7 @@ export abstract class IProjectionBuilderForReadModel<T> {
      * @param {ProjectionCallback<T>} method - Callback to call for each event.
      * @returns {IProjectionBuilderForReadModel<T>} The builder for continuation.
      */
-     abstract on(eventTypeId: EventTypeIdLike, generation: Generation | number, keySelectorCallback: KeySelectorBuilderCallback, callback: ProjectionCallback<T>): IProjectionBuilderForReadModel<T>;
+    abstract on(eventTypeId: EventTypeIdLike, generation: Generation | number, keySelectorCallback: KeySelectorBuilderCallback, callback: ProjectionCallback<T>): IProjectionBuilderForReadModel<T>;
 
     /**
      * Defines the projection to operate in a specific {@link ScopeId}.
@@ -60,6 +61,13 @@ export abstract class IProjectionBuilderForReadModel<T> {
      * @returns {IProjectionBuilderForReadModel<T>} The builder for continuation.
      */
     abstract inScope(scopeId: ScopeId | Guid | string): IProjectionBuilderForReadModel<T>;
+
+    /**
+     * Defines an alias for the projection.
+     * @param {ProjectionAliasLike} alias - The projection alias.
+     * @returns {IProjectionBuilderForReadModel<T>} The builder for continuation.
+     */
+    abstract withAlias(alias: ProjectionAliasLike): IProjectionBuilderForReadModel<T>;
 
     /**
      * Configures the projection to write copies of read models to a MongoDB collection.

--- a/Source/projections/Builders/ProjectionClassBuilder.ts
+++ b/Source/projections/Builders/ProjectionClassBuilder.ts
@@ -66,7 +66,7 @@ export class ProjectionClassBuilder<T> implements IEquatable {
             return undefined;
         }
 
-        return new Projection<T>(this.type.projectionId, this.type.type, this.type.scopeId, events, copies);
+        return new Projection<T>(this.type.projectionId, this.type.type, this.type.scopeId, events, copies, this.type.alias);
     }
 
     private tryAddAllOnMethods(events: EventTypeMap<[ProjectionCallback<T>, KeySelector]>, type: Constructor<any>, eventTypes: IEventTypes): boolean {

--- a/Source/projections/Builders/ProjectionDecoratedType.ts
+++ b/Source/projections/Builders/ProjectionDecoratedType.ts
@@ -6,6 +6,7 @@ import { Constructor } from '@dolittle/types';
 import { ScopeId } from '@dolittle/sdk.events';
 
 import { ProjectionId } from '../ProjectionId';
+import { ProjectionAlias } from '../ProjectionAlias';
 
 /**
  * Represents a projection created from the decorator.
@@ -15,11 +16,13 @@ export class ProjectionDecoratedType {
      * Initialises a new instance of the {@link ProjectionDecoratedType} class.
      * @param {ProjectionId} projectionId - The identifier of the projection.
      * @param {ScopeId} scopeId - The scope of the projection.
+     * @param {ProjectionAlias} alias - The alias of the projection.
      * @param {Constructor<any>} type - The decorated type.
      */
     constructor(
         readonly projectionId: ProjectionId,
         readonly scopeId: ScopeId,
+        readonly alias: ProjectionAlias,
         readonly type: Constructor<any>) {
     }
 }

--- a/Source/projections/Builders/ProjectionOptions.ts
+++ b/Source/projections/Builders/ProjectionOptions.ts
@@ -4,8 +4,12 @@
 import { Guid } from '@dolittle/rudiments';
 import { ScopeId } from '@dolittle/sdk.events';
 import { projection } from './projectionDecorator';
+import { ProjectionAliasLike } from '../ProjectionAlias';
 
 /**
  * Defines the options that can be defined in a {@link projection} decorator.
  */
-export type ProjectionOptions = { inScope?: ScopeId | Guid | string };
+export type ProjectionOptions = {
+    inScope?: ScopeId | Guid | string,
+    alias?: ProjectionAliasLike,
+};

--- a/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_conversions.ts
+++ b/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_conversions.ts
@@ -16,6 +16,7 @@ import { PropertyConversion } from '../../../../Copies/MongoDB/PropertyConversio
 import { on } from '../../../onDecorator';
 import { ProjectionDecoratedType } from '../../../ProjectionDecoratedType';
 import { ProjectionClassBuilder } from '../../../ProjectionClassBuilder';
+import { ProjectionAlias } from '../../../../ProjectionAlias';
 
 @copyProjectionToMongoDB()
 class Projection {
@@ -37,6 +38,7 @@ describeThis(__filename, () => {
     const decoratedType = new ProjectionDecoratedType(
         ProjectionId.from('53cad890-5b8a-4146-acce-29dc2dc8c43e'),
         ScopeId.from('28f6c232-cc11-493b-b032-398a5e651617'),
+        ProjectionAlias.from('alias'),
         Projection);
 
     const builder = new ProjectionClassBuilder(decoratedType);

--- a/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_copy_to_mongodb.ts
+++ b/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_copy_to_mongodb.ts
@@ -12,6 +12,7 @@ import { copyProjectionToMongoDB } from '../../../Copies/copyProjectionToMongoDB
 import { on } from '../../../onDecorator';
 import { ProjectionDecoratedType } from '../../../ProjectionDecoratedType';
 import { ProjectionClassBuilder } from '../../../ProjectionClassBuilder';
+import { ProjectionAlias } from '../../../../ProjectionAlias';
 
 @copyProjectionToMongoDB()
 class Projection {
@@ -23,6 +24,7 @@ describeThis(__filename, () => {
     const decoratedType = new ProjectionDecoratedType(
         ProjectionId.from('53cad890-5b8a-4146-acce-29dc2dc8c43e'),
         ScopeId.from('28f6c232-cc11-493b-b032-398a5e651617'),
+        ProjectionAlias.from('alias'),
         Projection);
 
     const builder = new ProjectionClassBuilder(decoratedType);

--- a/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_explicit_collection_name.ts
+++ b/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/with_explicit_collection_name.ts
@@ -12,6 +12,7 @@ import { copyProjectionToMongoDB } from '../../../Copies/copyProjectionToMongoDB
 import { on } from '../../../onDecorator';
 import { ProjectionDecoratedType } from '../../../ProjectionDecoratedType';
 import { ProjectionClassBuilder } from '../../../ProjectionClassBuilder';
+import { ProjectionAlias } from '../../../../ProjectionAlias';
 
 @copyProjectionToMongoDB('collection-name')
 class Projection {
@@ -23,6 +24,7 @@ describeThis(__filename, () => {
     const decoratedType = new ProjectionDecoratedType(
         ProjectionId.from('53cad890-5b8a-4146-acce-29dc2dc8c43e'),
         ScopeId.from('28f6c232-cc11-493b-b032-398a5e651617'),
+        ProjectionAlias.from('alias'),
         Projection);
 
     const builder = new ProjectionClassBuilder(decoratedType);

--- a/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/without_copy_to_mongodb.ts
+++ b/Source/projections/Builders/for_ProjectionClassBuilder/when_building/with_copies_to_mongodb/without_copy_to_mongodb.ts
@@ -11,6 +11,7 @@ import { ProjectionId } from '../../../../ProjectionId';
 import { on } from '../../../onDecorator';
 import { ProjectionDecoratedType } from '../../../ProjectionDecoratedType';
 import { ProjectionClassBuilder } from '../../../ProjectionClassBuilder';
+import { ProjectionAlias } from '../../../../ProjectionAlias';
 
 class Projection {
     @on('32e2aaca-2374-42f0-bcb5-7fb19501e3da', _ => _.keyFromEventSource())
@@ -21,6 +22,7 @@ describeThis(__filename, () => {
     const decoratedType = new ProjectionDecoratedType(
         ProjectionId.from('53cad890-5b8a-4146-acce-29dc2dc8c43e'),
         ScopeId.from('28f6c232-cc11-493b-b032-398a5e651617'),
+        ProjectionAlias.from('alias'),
         Projection);
 
     const builder = new ProjectionClassBuilder(decoratedType);

--- a/Source/projections/Builders/projectionDecorator.ts
+++ b/Source/projections/Builders/projectionDecorator.ts
@@ -10,6 +10,7 @@ import { ScopeId } from '@dolittle/sdk.events';
 import { ProjectionId } from '../ProjectionId';
 import { ProjectionDecoratedType } from './ProjectionDecoratedType';
 import { ProjectionOptions } from './ProjectionOptions';
+import { ProjectionAlias } from '../ProjectionAlias';
 
 const [decorator, getMetadata] = Decorators.createMetadataDecorator<ProjectionDecoratedType>('projection', 'projection', Decorators.DecoratorTarget.Class);
 
@@ -24,6 +25,7 @@ export function projection(projectionId: ProjectionId | Guid | string, options: 
         return new ProjectionDecoratedType(
             ProjectionId.from(projectionId),
             options.inScope ? ScopeId.from(options.inScope) : ScopeId.default,
+            ProjectionAlias.from(options.alias ?? type.name),
             type);
     });
 }

--- a/Source/projections/IProjection.ts
+++ b/Source/projections/IProjection.ts
@@ -9,6 +9,7 @@ import { ProjectionCopies } from './Copies/ProjectionCopies';
 import { DeleteReadModelInstance } from './DeleteReadModelInstance';
 import { EventSelector } from './EventSelector';
 import { ProjectionContext } from './ProjectionContext';
+import { ProjectionAlias } from './ProjectionAlias';
 import { ProjectionId } from './ProjectionId';
 
 /**
@@ -45,6 +46,16 @@ export abstract class IProjection<T> {
      * Gets the specification of read model copies to produce for the projection.
      */
     abstract readonly copies: ProjectionCopies;
+
+    /**
+     * Gets the alias for the projection.
+     */
+    abstract readonly alias: ProjectionAlias | undefined;
+
+    /**
+     * Gets a value indicating whether this projection has an alias or not.
+     */
+    abstract readonly hasAlias: boolean;
 
     /**
      * Handle an event and update a readmodel.

--- a/Source/projections/Internal/ProjectionProcessor.ts
+++ b/Source/projections/Internal/ProjectionProcessor.ts
@@ -64,6 +64,9 @@ export class ProjectionProcessor<T> extends Internal.EventProcessor<ProjectionId
         registerArguments.setScopeid(Guids.toProtobuf(this._projection.scopeId.value));
         registerArguments.setInitialstate(JSON.stringify(this._projection.initialState));
         registerArguments.setCopies(this.createCopiesSpecification());
+        if (this._projection.hasAlias) {
+            registerArguments.setAlias(this._projection.alias!.value);
+        }
 
         const events: ProjectionEventSelector[] = [];
         for (const eventSelector of this._projection.events) {

--- a/Source/projections/Projection.ts
+++ b/Source/projections/Projection.ts
@@ -13,17 +13,24 @@ import { MissingOnMethodForType } from './MissingOnMethodForType';
 import { ProjectionCallback } from './ProjectionCallback';
 import { ProjectionContext } from './ProjectionContext';
 import { ProjectionId } from './ProjectionId';
+import { ProjectionAlias } from './ProjectionAlias';
 
 /**
  * Represents an implementation of {@link IProjection<T>}.
  * @template T The type of the projection read model.
  */
 export class Projection<T> extends IProjection<T> {
+    /** @inheritdoc */
     readonly readModelType: Constructor<T> | undefined;
+
+    /** @inheritdoc */
     readonly initialState: T;
 
     /** @inheritdoc */
     readonly events: Iterable<EventSelector>;
+
+    /** @inheritdoc */
+    readonly hasAlias: boolean;
 
     /**
      * Initializes a new instance of {@link Projection}.
@@ -32,6 +39,7 @@ export class Projection<T> extends IProjection<T> {
      * @param {ScopeId} scopeId - The identifier of the scope the projection is in.
      * @param {EventTypeMap<[ProjectionCallback<any>, KeySelector]>} _eventMap - The events with respective callbacks and keyselectors used by the projection.
      * @param {ProjectionCopies} copies - The read model copies specification for the projection.
+     * @param {ProjectionAlias | undefined} alias - The optional projection alias.
      */
     constructor(
         readonly projectionId: ProjectionId,
@@ -39,6 +47,7 @@ export class Projection<T> extends IProjection<T> {
         readonly scopeId: ScopeId,
         private readonly _eventMap: EventTypeMap<[ProjectionCallback<any>, KeySelector]>,
         readonly copies: ProjectionCopies,
+        readonly alias: ProjectionAlias | undefined = undefined
     ) {
         super();
 
@@ -54,6 +63,8 @@ export class Projection<T> extends IProjection<T> {
             eventSelectors.push(new EventSelector(eventType, keySelector));
         }
         this.events = eventSelectors;
+
+        this.hasAlias = alias !== undefined;
     }
 
     /** @inheritdoc */

--- a/Source/projections/ProjectionAlias.ts
+++ b/Source/projections/ProjectionAlias.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ConceptAs, createIsConceptAsString } from '@dolittle/concepts';
+
+/**
+ * Defines the types that can be converted to an {@link ProjectionAlias}.
+ */
+export type ProjectionAliasLike = string | ProjectionAlias;
+
+/**
+ * Represents the alias for a Projection.
+ */
+export class ProjectionAlias extends ConceptAs<string, '@dolittle/sdk.projections.ProjectionAlias'> {
+    /**
+     * Initialises a new instance of the {@link ProjectionAlias} class.
+     * @param {string} alias - The event handler alias.
+     */
+    constructor(alias: string) {
+        super(alias, '@dolittle/sdk.projections.ProjectionAlias');
+    }
+
+    /**
+     * Creates an {@link ProjectionAlias} from an {@link ProjectionAlias}.
+     * @param {ProjectionAliasLike} alias - The projection alias.
+     * @returns {ProjectionAlias} The created projection alias concept.
+     */
+    static from(alias: ProjectionAliasLike): ProjectionAlias {
+        if (isProjectionAlias(alias)) return alias;
+        return new ProjectionAlias(alias);
+    }
+}
+
+/**
+ * Checks whether or not an object is an instance of {@link ProjectionAlias}.
+ * @param {any} object - The object to check.
+ * @returns {boolean} True if the object is an {@link ProjectionAlias}, false if not.
+ */
+export const isProjectionAlias = createIsConceptAsString(ProjectionAlias, '@dolittle/sdk.projections.ProjectionAlias');

--- a/Source/projections/_exports.ts
+++ b/Source/projections/_exports.ts
@@ -18,6 +18,7 @@ export { KeySelector } from './KeySelector';
 export { MissingOnMethodForType } from './MissingOnMethodForType';
 export { PartitionIdKeySelector } from './PartitionIdKeySelector';
 export { Projection } from './Projection';
+export { ProjectionAlias, isProjectionAlias, ProjectionAliasLike} from './ProjectionAlias';
 export { ProjectionCallback } from './ProjectionCallback';
 export { ProjectionContext } from './ProjectionContext';
 export { ProjectionId, isProjectionId } from './ProjectionId';

--- a/Source/projections/package.json
+++ b/Source/projections/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.7.0",
+        "@dolittle/contracts": "6.8.0-merry.2",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.7.0",
+        "@dolittle/runtime.contracts": "6.8.0-merry.2",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",

--- a/Source/projections/package.json
+++ b/Source/projections/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.8.0-merry.2",
+        "@dolittle/contracts": "6.8.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.8.0-merry.2",
+        "@dolittle/runtime.contracts": "6.8.0",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",

--- a/Source/protobuf/package.json
+++ b/Source/protobuf/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.8.0-merry.2",
+        "@dolittle/contracts": "6.8.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.execution": "23.1.0"

--- a/Source/protobuf/package.json
+++ b/Source/protobuf/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.7.0",
+        "@dolittle/contracts": "6.8.0-merry.2",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.execution": "23.1.0"

--- a/Source/resources/package.json
+++ b/Source/resources/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.8.0-merry.2",
+        "@dolittle/contracts": "6.8.0",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.8.0-merry.2",
+        "@dolittle/runtime.contracts": "6.8.0",
         "@dolittle/sdk.execution": "23.1.0",
         "@dolittle/sdk.projections": "23.1.0",
         "@dolittle/sdk.protobuf": "23.1.0",

--- a/Source/resources/package.json
+++ b/Source/resources/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.7.0",
+        "@dolittle/contracts": "6.8.0-merry.2",
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.7.0",
+        "@dolittle/runtime.contracts": "6.8.0-merry.2",
         "@dolittle/sdk.execution": "23.1.0",
         "@dolittle/sdk.projections": "23.1.0",
         "@dolittle/sdk.protobuf": "23.1.0",

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -45,7 +45,7 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/runtime.contracts": "6.7.0",
+        "@dolittle/runtime.contracts": "6.8.0-merry.2",
         "@dolittle/sdk.aggregates": "23.1.0",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.common": "23.1.0",

--- a/Source/sdk/package.json
+++ b/Source/sdk/package.json
@@ -45,7 +45,7 @@
         "lint:fix": "eslint --quiet --ext .ts ./ --fix"
     },
     "dependencies": {
-        "@dolittle/runtime.contracts": "6.8.0-merry.2",
+        "@dolittle/runtime.contracts": "6.8.0",
         "@dolittle/sdk.aggregates": "23.1.0",
         "@dolittle/sdk.artifacts": "23.1.0",
         "@dolittle/sdk.common": "23.1.0",

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.8.0-merry.2",
+        "@dolittle/contracts": "6.8.0",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",

--- a/Source/services/package.json
+++ b/Source/services/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@dolittle/concepts": "6.0.0",
-        "@dolittle/contracts": "6.7.0",
+        "@dolittle/contracts": "6.8.0-merry.2",
         "@dolittle/rudiments": "6.0.0",
         "@dolittle/sdk.common": "23.1.0",
         "@dolittle/sdk.dependencyinversion": "23.1.0",

--- a/Source/tenancy/package.json
+++ b/Source/tenancy/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.7.0",
+        "@dolittle/runtime.contracts": "6.8.0-merry.2",
         "@dolittle/sdk.execution": "23.1.0",
         "@dolittle/sdk.protobuf": "23.1.0",
         "@dolittle/sdk.resilience": "23.1.0",

--- a/Source/tenancy/package.json
+++ b/Source/tenancy/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@dolittle/rudiments": "6.0.0",
-        "@dolittle/runtime.contracts": "6.8.0-merry.2",
+        "@dolittle/runtime.contracts": "6.8.0",
         "@dolittle/sdk.execution": "23.1.0",
         "@dolittle/sdk.protobuf": "23.1.0",
         "@dolittle/sdk.resilience": "23.1.0",


### PR DESCRIPTION
## Summary

Adds aliases to Projections, in the same way we have for Event Handlers. They default to the name of the read model class, and can be overridden with a decorator option or a builder method.

### Added

- An optional `alias` property on the `@projection` decorator options.
- A `.withAlias` method on the Projection builder API. 