### PR TITLE
Bind IDolittleClient and DolittleClient in IoC

### DIFF
--- a/Source/sdk/DolittleClient.ts
+++ b/Source/sdk/DolittleClient.ts
@@ -345,6 +345,8 @@ export class DolittleClient extends IDolittleClient {
         this._serviceProviderBuilder.addServices((bindings) => {
             bindings.bind('logger').toInstance(logger);
             bindings.bind('Logger').toInstance(logger);
+            bindings.bind(DolittleClient).toInstance(this);
+            bindings.bind(IDolittleClient).toInstance(this);
         });
 
         this._serviceProviderBuilder.addTenantServices((bindings, tenant) => {


### PR DESCRIPTION
## Summary

Binds up the `IDolittleClient` and `DolittleClient` in the IoC container

### Fixed

- The `IDolittleClient` and `DolittleClient` should be bound up in the IoC container.